### PR TITLE
aact-947:  Upgrade to ruby 2.4.5, bundle install failed on capybara-w…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,8 +75,8 @@ end
 
 group :test do
   gem "database_cleaner"
-#  gem 'capybara'
-#  gem "capybara-webkit"
+  gem 'capybara'
+  gem "capybara-webkit"
   gem 'selenium-webdriver' # For Firefox
   gem 'chromedriver-helper'
   gem "formulaic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    capybara-webkit (1.15.1)
+      capybara (>= 2.3, < 4.0)
+      json
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
@@ -346,6 +349,8 @@ DEPENDENCIES
   bundler-audit (>= 0.5.0)
   capistrano (~> 3.8)
   capistrano-rails (~> 1.2)
+  capybara
+  capybara-webkit
   chromedriver-helper
   coderay
   database_cleaner


### PR DESCRIPTION
…ebkit.  Had to reinstall qt5 to get it to install and successfully run spec tests.  Used advice here: https://stackoverflow.com/questions/17075380/can-i-use-homebrews-qt5-with-capybara-webkit