### PR TITLE
hard coded the studies count in pages psql local and remote login

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,4 +414,4 @@ RUBY VERSION
    ruby 2.4.5p335
 
 BUNDLED WITH
-   2.2.25
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,4 +414,4 @@ RUBY VERSION
    ruby 2.4.5p335
 
 BUNDLED WITH
-   1.17.3
+   2.2.25

--- a/app/views/pages/_psql_local_login.html.erb
+++ b/app/views/pages/_psql_local_login.html.erb
@@ -27,9 +27,9 @@
     <span class='command-response'> </span>
     <span class='command-response'>  count</span>
     <span class='command-response'>  --------</span>
-    <span class='command-response'>  <%= Public::Study.count %></span>
+    <span class='command-response'>  387486</span>
     <span class='command-response'>  (1 row)</span>
     <span class='command-response'> </span>
-    <span class='command-prompt'>aact=# _</span>
+    <span class='command-prompt'>aact=# _</span>                                                                                                                                             <span class='command-entry'> As of 08/24/21</span>
   </p>
 </pre>

--- a/app/views/pages/_psql_remote_login.html.erb
+++ b/app/views/pages/_psql_remote_login.html.erb
@@ -22,9 +22,9 @@ The <i><span class='command-prompt'>aact=# </span></i> prompt indicates that you
     <span class='command-response'> </span>
     <span class='command-response'>  count</span>
     <span class='command-response'>  --------</span>
-    <span class='command-response'>  <%= Public::Study.count %></span>
+    <span class='command-response'>  387486</span>
     <span class='command-response'>  (1 row)</span>
     <span class='command-response'> </span>
-    <span class='command-prompt'>aact=# _</span>
+    <span class='command-prompt'>aact=# _</span>                                                                                                                                             <span class='command-entry'> As of 08/24/21</span>
   </p>
 </pre>

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 13.1
--- Dumped by pg_dump version 13.1
+-- Dumped from database version 13.3
+-- Dumped by pg_dump version 13.3
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;


### PR DESCRIPTION
Creating a pull request so as to update files _psql_local_login.html.erb and _psql_remote_login.html.erb:

1. Deleted code "Public::Study.count" and replace with hardcoded value of "387486".
2. Added code to display message, "As of 08/24/21", that shows when the query was run. Locate message on the lower right hand corner of window.

http://localhost:3000/snapshots:

<img width="1280" alt="Screen Shot 2021-08-25 at 3 36 32 PM" src="https://user-images.githubusercontent.com/81119399/130873727-13a5fc22-d8a0-4db4-9863-5f685e29769f.png">

http://localhost:3000/psql:

<img width="1280" alt="Screen Shot 2021-08-25 at 3 41 25 PM" src="https://user-images.githubusercontent.com/81119399/130873808-db119a24-2f40-43ce-93b6-5db76f7e52cd.png">



