### PR TITLE
Fix/AACT-15: upgrade to bootstrap 5.0+

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,4 +444,4 @@ RUBY VERSION
    ruby 2.4.5p335
 
 BUNDLED WITH
-   1.17.3
+   2.2.25

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,4 +444,4 @@ RUBY VERSION
    ruby 2.4.5p335
 
 BUNDLED WITH
-   2.2.25
+   1.17.3

--- a/app/views/includes/_main_header.html.erb
+++ b/app/views/includes/_main_header.html.erb
@@ -1,7 +1,7 @@
 <div id='navbar-top' class="navbar navbar-top">
 
   <% if user_signed_in? %>
-   
+
       <p class='user-logged-in'>logged in as <%= current_user.full_name %></p>
     <p class='user-info'>
         <%= link_to "Edit Profile", edit_user_registration_path %>&nbsp;&nbsp;
@@ -21,7 +21,7 @@
       <%= image_tag("full_logo.jpg", class:"logo",  height: '120', width: '300') %>
       <% end %>
     </div>
-  <button class="navbar-toggler navbar-dark bg-aact" type="button" data-toggle="collapse" data-target="#topNavToggler" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+  <button class="navbar-toggler navbar-dark bg-aact" type="button" data-bs-toggle="collapse" data-bs-target="#topNavToggler" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
   <div class="collapse navbar-collapse" id="topNavToggler">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,10 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
   <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.9.2/dist/umd/popper.min.js" integrity="sha384-IQsoLXl5PILFhosVNubq5LC7Qb9DXgDA9i+tQ8Zj3iwWAwPtgFTxbJ8NT4GN1R8p" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.min.js" integrity="sha384-cVKIPhGWiC2Al4u+LWgxfKTRIcfu0JTxR+EQDz/bgldoEyl4H0zUF0QKbrJ0EcQF" crossorigin="anonymous"></script>
 
   <link href='https://fonts.googleapis.com/css?family=Roboto:400,700,300,400italic' rel='stylesheet' type='text/css'>
   <%#
@@ -15,7 +15,6 @@
   %>
   <title>AACT Database | Clinical Trials Transformation Initiative</title>
 
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= include_gon %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Creating a pull request so as to incorporate AACT-15: Upgrade to bootstrap 5.0+ in AACT-admin.

Updated to reflect upgrade of bootstrap 5.0.2 and popperJS in application.html.erb

Updated navbar "hamburger" to reflect bootstrap 5.0.2. upgrade in _main_header.html.erb

Reverted back to bundler 1.17.3 in Gemfile.lock

<img width="1280" alt="Screen Shot 2021-09-23 at 1 08 57 PM" src="https://user-images.githubusercontent.com/81119399/134576769-a10334d7-4654-42e7-8b9d-8cad974d3dd7.png">


