### PR TITLE
Fix/AACT-283 button styling

### DIFF
--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -1,6 +1,6 @@
 @import "variables";
 @import "library";
-button, input[type="submit"], a.button {
+button.old-btn, input[type="submit"].old-btn, a.button {
   background-color: $button-color;
   color: $button-text-color;
   font-size: 1rem;
@@ -76,7 +76,7 @@ button, input[type="submit"], a.button {
 
   &.large {
     font-size: 18px;
-    padding: 20px 40px;
+    padding: 20px 20px;
     border-radius: $border-radius;
 
     i.fa {

--- a/app/assets/stylesheets/base/_buttons.scss
+++ b/app/assets/stylesheets/base/_buttons.scss
@@ -76,7 +76,7 @@ button.old-btn, input[type="submit"].old-btn, a.button {
 
   &.large {
     font-size: 18px;
-    padding: 20px 20px;
+    padding: 20px 40px;
     border-radius: $border-radius;
 
     i.fa {

--- a/app/assets/stylesheets/includes/_buttons.scss
+++ b/app/assets/stylesheets/includes/_buttons.scss
@@ -1,7 +1,7 @@
 @import "../base/variables";
 @import "../base/library";
 
-button, input[type="submit"], a.button {
+button.old-btn, input[type="submit"].old-btn, a.button {
   background-color: $button-color;
   color: $button-text-color;
   font-size: 1rem;

--- a/app/assets/stylesheets/includes/footer.scss
+++ b/app/assets/stylesheets/includes/footer.scss
@@ -9,7 +9,7 @@ span.circleButtons {
 
 div.circleButtons {
   margin-bottom: 4rem;
-  @include display-flex;
+  // @include display-flex;
   @include align-items(center);
   @include justify-content(center);
 

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions", class: "btn btn-primary old-btn" %>
+    <%= f.submit "Resend confirmation instructions", class: "old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit "Resend confirmation instructions", class: "btn btn-primary old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -10,7 +10,7 @@
   <div><%= f.label :password_confirmation, "Confirm new password" %><br />
     <%= f.password_field :password_confirmation, autocomplete: "off" %></div>
 
-  <div><%= f.submit "Change my password" %></div>
+  <div><%= f.submit "Change my password", class: "btn btn-primary old-btn" %></div>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Send me reset password instructions", class: "btn btn-primary old-btn" %>
+    <%= f.submit "Send me reset password instructions", class: "old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Send me reset password instructions", class: "btn btn-primary" %>
+    <%= f.submit "Send me reset password instructions", class: "btn btn-primary old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/update.html.erb
+++ b/app/views/devise/passwords/update.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Send me reset password instructions", class: "btn btn-primary" %>
+    <%= f.submit "Send me reset password instructions", class: "btn btn-primary old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/update.html.erb
+++ b/app/views/devise/passwords/update.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Send me reset password instructions", class: "btn btn-primary old-btn" %>
+    <%= f.submit "Send me reset password instructions", class: "old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/_create.html.erb
+++ b/app/views/devise/registrations/_create.html.erb
@@ -35,7 +35,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Sign up", class: "btn btn-primary" %>
+    <%= f.submit "Sign up", class: "btn btn-primary old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/_create.html.erb
+++ b/app/views/devise/registrations/_create.html.erb
@@ -35,7 +35,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Sign up", class: "btn btn-primary old-btn" %>
+    <%= f.submit "Sign up", class: "old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/registrations/_form.html.erb
+++ b/app/views/devise/registrations/_form.html.erb
@@ -34,9 +34,9 @@
   </div>
 
   <div class="form-group">
-    <span class='floatLeft'><%= f.submit "Update", class: "btn btn-primary" %></span>
+    <span class='floatLeft'><%= f.submit "Update", class: "btn btn-primary old-btn" %></span>
   </div>
 
 <% end %>
-<span class='floatRight'><%= button_to "Remove my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger" %></span>
+<span class='floatRight'><%= button_to "Remove my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-danger old-btn" %></span>
 <h2 class='spacing hack'></h2>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Sign in", class: "btn btn-primary old-btn" %>
+    <%= f.submit "Sign in", class: "old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "Sign in", class: "btn btn-primary" %>
+    <%= f.submit "Sign in", class: "btn btn-primary old-btn" %>
   </div>
 <% end %>
 

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -6,7 +6,7 @@
   <div><%= f.label :email %><br />
   <%= f.email_field :email, autofocus: true %></div>
 
-  <div><%= f.submit "Resend unlock instructions" %></div>
+  <div><%= f.submit "Resend unlock instructions", class: "btn btn-primary old-btn" %></div>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -6,7 +6,7 @@
   <div><%= f.label :email %><br />
   <%= f.email_field :email, autofocus: true %></div>
 
-  <div><%= f.submit "Resend unlock instructions", class: "btn btn-primary old-btn" %></div>
+  <div><%= f.submit "Resend unlock instructions", class: "old-btn" %></div>
 <% end %>
 
 <%= render "devise/shared/links" %>

--- a/app/views/use_cases/_form.html.erb
+++ b/app/views/use_cases/_form.html.erb
@@ -69,8 +69,8 @@
 
   <br>
   <p>By pressing this button, you agree to share this information with the research community; your information will be published to the AACT Gallery.</p>
-  <div class="button actions">
-    <p><%= f.submit "Create Use Case",  class: "btn btn-primary old-btn"%></p>
+  <div>
+    <p><%= f.submit "Create Use Case",  class: "old-btn"%></p>
   </div>
 
 <% end %>

--- a/app/views/use_cases/_form.html.erb
+++ b/app/views/use_cases/_form.html.erb
@@ -70,7 +70,7 @@
   <br>
   <p>By pressing this button, you agree to share this information with the research community; your information will be published to the AACT Gallery.</p>
   <div class="button actions">
-    <p><%= f.submit %></p>
+    <p><%= f.submit "Create Use Case",  class: "btn btn-primary old-btn"%></p>
   </div>
 
 <% end %>

--- a/app/views/use_cases/index.html.erb
+++ b/app/views/use_cases/index.html.erb
@@ -54,7 +54,7 @@
 
       <p class='useCaseInvitation'>
         <%= button_to "I'd like to showcase my work in the AACT Gallery", new_use_case_path, :id => "addUseCaseButton",
-       :class => "inbox-sf-add-btn tip", :method => :get %>
+       :class => "inbox-sf-add-btn tip old-btn", :method => :get %>
       </p>
 
   </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,7 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
   config.assets.debug = true
   config.assets.digest = true
+  config.assets.compile = true
   config.assets.raise_runtime_errors = true
   config.action_view.raise_on_missing_translations = true
   config.action_mailer.default_url_options = { host: host }


### PR DESCRIPTION
Added `old-btn` class to buttons CSS so new buttons can use Bootstrap styling and won't be overwritten by the current one.
Also aligned text in some buttons (see screenshots).

---------------------------
"Shared data" is aligned:

<img src="https://user-images.githubusercontent.com/56514545/148559091-dc47aa8f-50ca-402b-bb2f-7ee993d35fbc.png" width= "400"><img src="https://user-images.githubusercontent.com/56514545/148559118-332fb19c-8b28-4baa-8c8f-8367790bc28a.png" width= "400">

---------------
<img src="https://user-images.githubusercontent.com/56514545/148559427-eae99c85-2f73-416e-aed5-3dd3d49ad082.png" width= "400"><img src="https://user-images.githubusercontent.com/56514545/148559413-a1a4a886-652a-4aa6-90c8-faf6e9bfa617.png" width= "400">






