### PR TITLE
Fix/AACT-328 The users link should use the admin? method

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user, only: [:index, :show, :edit, :destroy]
+  before_action :is_admin?, only: [:index, :show, :edit, :destroy]
 
   def index
     @user_count = User.all.size
@@ -33,15 +33,4 @@ class UsersController < ApplicationController
       params.fetch(:user, {})
       params.require(:user).permit(:utf8, :authenticity_token, :commit, :_method, :first_name, :last_name, :email, :username)
     end
-
-    def authenticate_user
-      render plain: "Sorry - This page is intentionally inaccessible." if !current_user_is_an_admin?
-    end
-
-    def current_user_is_an_admin?
-      return false if !current_user
-      col=AACT::Application::AACT_ADMIN_USERNAMES.split(',')
-      col.include? current_user.username
-    end
 end
-

--- a/app/views/includes/_circle_buttons.html.erb
+++ b/app/views/includes/_circle_buttons.html.erb
@@ -1,46 +1,39 @@
 <div class="circleButtons container">
   <div class="row">
-    <div class="col-sm">
+    <div class="d-flex justify-content-sm-center">
       <a href="/connect">
         <div class="iconWrap">
           <%= fa_icon('plug') %>
         </div>
         <span class='circleButtons'>Connect</span>
       </a>
-    </div>
-    <div class="col-sm">
       <a href="/download">
         <div class="iconWrap">
           <%= fa_icon('download') %>
         </div>
         <span class='circleButtons'>Download</span>
       </a>
-    </div>
-    <div class="col-sm">
       <a href="/learn_more">
         <div class="iconWrap">
           <%= fa_icon('university') %>
         </div>
         <span class='circleButtons'>Learn</span>
       </a>
-    </div>
-    <div class="col-sm">
       <a href="/shared_data">
         <div class="iconWrap">
           <%= fa_icon('briefcase') %>
         </div>
         <span class='circleButtons'>Shared Data</span>
       </a>
-    </div>
-    <% if (!current_user.nil? and current_user.admin?) %>
-      <div class="col-sm">
+
+      <% if (!current_user.nil? and current_user.admin?) %>
         <a href="/users">
           <div class="iconWrap">
             <%= fa_icon('address-card') %>
           </div>
           <span class='circleButtons'>Users</span>
         </a>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/includes/_circle_buttons.html.erb
+++ b/app/views/includes/_circle_buttons.html.erb
@@ -32,13 +32,15 @@
         <span class='circleButtons'>Shared Data</span>
       </a>
     </div>
-    <% if  (!current_user.nil? and @aact_admin_usernames.split(',').include? current_user.username) %>
-      <a href="/users">
-        <div class="iconWrap">
-          <%= fa_icon('address-card') %>
-        </div>
-        <span class='circleButtons'>Users</span>
-      </a>
+    <% if (!current_user.nil? and current_user.admin?) %>
+      <div class="col-sm">
+        <a href="/users">
+          <div class="iconWrap">
+            <%= fa_icon('address-card') %>
+          </div>
+          <span class='circleButtons'>Users</span>
+        </a>
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
Updated the circle buttons view logic so that it checks current_user.admin? instead of checking the environment variable to see if the user is an admin.

Changed before_action in UsersController to is_admin?

Removed the methods authenticate_user and current_user_is_an_admin? in UsersController.

<img width="1280" alt="Screen Shot 2022-03-02 at 12 12 51 PM" src="https://user-images.githubusercontent.com/81119399/156447097-f8c79b20-57b4-4b9d-bb26-9e8420db6c00.png">

<img width="1280" alt="Screen Shot 2022-03-02 at 12 14 05 PM" src="https://user-images.githubusercontent.com/81119399/156447183-91460b13-a8dc-42e2-84bc-4f74fb08301e.png">

<img width="1280" alt="Screen Shot 2022-03-02 at 12 14 51 PM" src="https://user-images.githubusercontent.com/81119399/156447217-65752f19-c956-4531-bd90-bbb1a44b2d3c.png">

