### PR TITLE
Added Base model to be able to connect to the aact-core database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ Administer AACT: Aggregated Analysis of ClinicalTrials.gov
 ## Getting Started
 
 You should always setup AACT Core before setting up AACT Admin. AACT Admin relies on AACT Core. So if you haven’t set up AACT Core yet, please do so now. [aact core](https://github.com/ctti-clinicaltrials/aact)  
-Make sure you've set values for the environmental variables 
+Make sure you've set values for the environmental variables
 - `AACT_DB_SUPER_USERNAME=<superuser_name>`  
 - `AACT_PASSWORD=<superuser_password>`  
 - `AACT_PUBLIC_DATABASE_NAME=aact`  
 - `PUBLIC_DB_USER=<superuser_name>`  
 - `PUBLIC_DB_PASS=<superuser_password>`  
 - `PUBLIC_DB_HOST=<public_host>` could be the aact site `aact-db.ctti-clinicaltrials.org`
-- `AACT_ALT_PUBLIC_DATABASE_NAME=aact_alt`  
+- `AACT_ALT_PUBLIC_DATABASE_NAME=aact_alt`
+- `AACT_CORE_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@localhost:5432/aact>`  
 These variables should have been set when you setup AACT Core. If any are missing you should add them to where you store your variables (for instance ".bash_profile" or ".zshrc").  
 
 Be sure to call `source` on the file where your passwords are. Example `source ~/.bash_profile` so they are reloaded into the terminal.   

--- a/app/models/core/base.rb
+++ b/app/models/core/base.rb
@@ -1,0 +1,6 @@
+module Core
+  class Base < ActiveRecord::Base
+    self.abstract_class = true
+    establish_connection(AACT::Application::AACT_CORE_DATABASE_URL)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -75,5 +75,8 @@ module AACT
     #  LD_LIBRARY_PATH
     #  PATH
 
+    # aact-core database connection
+    AACT_CORE_DATABASE_URL  = ENV['AACT_CORE_DATABASE_URL']
+
   end
 end

--- a/spec/models/core/base_spec.rb
+++ b/spec/models/core/base_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Core::Base, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Added Base model to be able to connect to the aact-core database.
Updated application.rb with the aact-core database url. 
Added aact-core database url environment variable to the Readme.md documentation.

The screenshot below shows a successful connection to the aact-core database using the AACT_CORE_DATABASE_URL :

<img width="1280" alt="Screen Shot 2022-03-04 at 4 26 22 PM" src="https://user-images.githubusercontent.com/81119399/158002421-375f9582-d87c-429b-8f7e-04621d0268be.png">

