### PR TITLE
Added rendering of the Markdown processing to the body of the Release Notes.

### DIFF
--- a/app/views/release_notes/index.html.erb
+++ b/app/views/release_notes/index.html.erb
@@ -5,7 +5,7 @@
       <hr/>
       <h3><%= release.title %> <i> (<%= release.released_on.strftime('%B %d, %Y') %>) </i></h3>
       <h5><%= release.subtitle %></h5>
-      <p><%= release.body %></p>
+      <p><%= markdown(release.body) %></p>
 <% end %>
 
 <hr/> <%= render 'release_notes/v6.0.0' %>


### PR DESCRIPTION
Updated Release Notes view page file index.html.erb

Rendering of the Markdown processing to the body of the Release Notes:

<img width="1280" alt="Screen Shot 2022-03-17 at 3 07 05 PM" src="https://user-images.githubusercontent.com/81119399/158904956-5e3bdebc-c4c2-4ff4-9e1b-bdcb27c005eb.png">

<img width="1280" alt="Screen Shot 2022-03-17 at 3 07 32 PM" src="https://user-images.githubusercontent.com/81119399/158904987-32f69411-306e-4c22-ae12-342fe010ce03.png">


