### PR TITLE
Created Base model to be able to connect to the aact-query database.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Make sure you've set values for the environmental variables
 - `PUBLIC_DB_HOST=<public_host>` could be the aact site `aact-db.ctti-clinicaltrials.org`
 - `AACT_ALT_PUBLIC_DATABASE_NAME=aact_alt`
 - `AACT_CORE_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@localhost:5432/aact>`  
+- `AACT_QUERY_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@aact-db.ctti-clinicaltrials.org:5432/aact>`
 These variables should have been set when you setup AACT Core. If any are missing you should add them to where you store your variables (for instance ".bash_profile" or ".zshrc").  
 
 Be sure to call `source` on the file where your passwords are. Example `source ~/.bash_profile` so they are reloaded into the terminal.   

--- a/app/models/query/base.rb
+++ b/app/models/query/base.rb
@@ -1,0 +1,6 @@
+module Query
+  class Base < ActiveRecord::Base
+    self.abstract_class = true
+    establish_connection(AACT::Application::AACT_QUERY_DATABASE_URL)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,8 @@ module AACT
     # aact-core database connection
     AACT_CORE_DATABASE_URL  = ENV['AACT_CORE_DATABASE_URL']
 
+    # aact-query database connection
+    AACT_QUERY_DATABASE_URL  = ENV['AACT_QUERY_DATABASE_URL']
+
   end
 end

--- a/spec/models/query/base_spec.rb
+++ b/spec/models/query/base_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Query::Base, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Added Base model to be able to connect to the aact-query database.
Updated application.rb with the aact-query database url.
Added aact-query database url environment variable to the README.md documentation.

The screenshot below shows a successful connection to the aact-query database using the AACT_QUERY_DATABASE_URL :

<img width="1280" alt="Screen Shot 2022-03-22 at 10 05 22 PM" src="https://user-images.githubusercontent.com/81119399/159629471-adaca6f5-cde8-450d-afcf-573aff3a0f63.png">

