### PR TITLE
Release 5.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Make sure you've set values for the environmental variables
 - `PUBLIC_DB_HOST=<public_host>` could be the aact site `aact-db.ctti-clinicaltrials.org`
 - `AACT_ALT_PUBLIC_DATABASE_NAME=aact_alt`
 - `AACT_CORE_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@localhost:5432/aact>`  
+- `AACT_QUERY_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@aact-db.ctti-clinicaltrials.org:5432/aact>`
 These variables should have been set when you setup AACT Core. If any are missing you should add them to where you store your variables (for instance ".bash_profile" or ".zshrc").  
 
 Be sure to call `source` on the file where your passwords are. Example `source ~/.bash_profile` so they are reloaded into the terminal.   

--- a/app/assets/stylesheets/base/base.scss
+++ b/app/assets/stylesheets/base/base.scss
@@ -69,10 +69,15 @@ table.regularDisplay {
    float: right;
 }
 
-html {
-    height: 100%;
-    padding-left: 100px;
-    padding-right: 100px;
+// html {
+    // height: 100%;
+    // padding-left: 100px;
+    // padding-right: 100px;
+// }
+
+.footer {
+  padding-left: 0 !important;
+  width: 100% !important;
 }
 
 table.regularDisplay, ul.regularDisplay, ol.regularDisplay {
@@ -125,6 +130,9 @@ div.wrap {
 }
 
 body {
+  height: 100%;
+  padding-left: 100px;
+  padding-right: 100px;
   background: transparent !important;
   font-size: 0px !important;
   min-height: 100%  !important;

--- a/app/assets/stylesheets/base/base.scss
+++ b/app/assets/stylesheets/base/base.scss
@@ -125,10 +125,6 @@ ul.indent {
     display: none;
 }
 
-div.wrap {
-  position: relative;
-}
-
 body {
   height: 100%;
   padding-left: 100px;
@@ -285,9 +281,6 @@ pre {
   position: relative;
 }
 
-div.wrap {
-  @extend %container;
-}
 
 a.card {
   background-color: rgb(249,249,249);

--- a/app/assets/stylesheets/dictionary/data_dictionary.scss
+++ b/app/assets/stylesheets/dictionary/data_dictionary.scss
@@ -10,6 +10,9 @@ span.enum {
 
 table.dictionaryDisplay {
   box-shadow: 6px 6px 5px #888888;
+  margin-bottom: 40px;
+  border-style: solid;
+  border-width: 1px;
   border-spacing: 0px;
 
   th {
@@ -116,26 +119,19 @@ label:hover {
 }
 
 section.dataDictionaryShow {
-  padding-bottom: 500px;
 
   h2 {
     padding-top: 60px;
-    border-bottom: 1px solid $primary;
   }
 
   h4 {
     padding-top: 40px;
-    border-bottom: 1px solid $grey;
   }
 
   ul {
     margin-bottom: 0px;
   }
 
-  div.wrap {
-    display: block;
-    margin: 0 auto;
-  }
 
   div.gridContainer {
 //    @include columnify(12, true);

--- a/app/assets/stylesheets/pages/connect.scss
+++ b/app/assets/stylesheets/pages/connect.scss
@@ -84,7 +84,6 @@ div.credentialRow {
 
 section.pgAdmin, section.rAccess, section.sasAccess, section.psqlAccess, section.apiAccess {
   background-color: $white;
-  padding-bottom: 400px;
 
   img {
     max-width: 70%;

--- a/app/assets/stylesheets/pages/considerations.scss
+++ b/app/assets/stylesheets/pages/considerations.scss
@@ -3,7 +3,6 @@
 
 section.pointsToConsider {
   background-color: $white;
-  padding-bottom: 400px;
 
   h1 {
     padding-top: 80px;

--- a/app/assets/stylesheets/pages/considerations.scss
+++ b/app/assets/stylesheets/pages/considerations.scss
@@ -4,21 +4,4 @@
 section.pointsToConsider {
   background-color: $white;
 
-  h1 {
-    padding-top: 80px;
-  }
-
-  h2 {
-    padding-top: 40px;
-  }
-
-  h4 {
-    padding-top: 30px;
-  }
-
-  div.wrap {
-    display: block;
-    margin: 0 auto;
-    font-family: Roboto;
-  }
 }

--- a/app/assets/stylesheets/pages/learn_more.scss
+++ b/app/assets/stylesheets/pages/learn_more.scss
@@ -1,9 +1,6 @@
 @import "../base/variables";
 @import "../base/library";
 
-div.basicHero {
-  padding: 40px 0px;
-}
 
 section.learnMore {
   background-color: $white;

--- a/app/assets/stylesheets/shared_data/index.scss
+++ b/app/assets/stylesheets/shared_data/index.scss
@@ -92,6 +92,10 @@ h1.projects {
   margin-left: 1px;
 }
 
+h2 {
+  color: #26657a;
+}
+
 h3 {
   color: #26657a;
 }

--- a/app/assets/stylesheets/shared_data/index.scss
+++ b/app/assets/stylesheets/shared_data/index.scss
@@ -92,9 +92,10 @@ h1.projects {
   margin-left: 1px;
 }
 
-.projectExplanation {
-  font-size: 1.8rem;
+h3 {
+  color: #26657a;
 }
+
 
 .projectLabel {
   padding-top: 1rem;

--- a/app/assets/stylesheets/shared_data/index.scss
+++ b/app/assets/stylesheets/shared_data/index.scss
@@ -96,6 +96,10 @@ h3 {
   color: #26657a;
 }
 
+h4 {
+  color: #26657a;
+}
+
 
 .projectLabel {
   padding-top: 1rem;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,7 @@
+class EventsController < ApplicationController
+
+  def index
+    @load_events = Core::LoadEvent.all.order(created_at: :desc)
+  end
+
+end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -9,7 +9,10 @@ class PagesController < ApplicationController
   end
 
   def snapshots
-    set_daily_monthly_snapshot_files
+    # daily
+    @daily = Core::FileRecord.daily('snapshot')
+    # monthly
+    @monthly = Core::FileRecord.monthly('snapshot')
   end
 
   def pipe_files

--- a/app/models/core/file_record.rb
+++ b/app/models/core/file_record.rb
@@ -1,4 +1,14 @@
 module Core
   class FileRecord < Core::Base
+
+
+    def self.daily(file_type)
+      where(created_at: (Date.today.beginning_of_month..DateTime.current), file_type: file_type)
+    end
+
+    def self.monthly(file_type)
+      where("created_at < :end_date", end_date: Date.today.beginning_of_month).where(file_type: file_type)
+    end
+
   end
 end

--- a/app/models/core/file_record.rb
+++ b/app/models/core/file_record.rb
@@ -1,7 +1,5 @@
 module Core
   class FileRecord < Core::Base
-
-
     def self.daily(file_type)
       where(created_at: (Date.today.beginning_of_month..DateTime.current), file_type: file_type)
     end

--- a/app/models/core/load_event.rb
+++ b/app/models/core/load_event.rb
@@ -1,0 +1,4 @@
+module Core
+  class LoadEvent < Core::Base
+  end
+end

--- a/app/models/core/verifier.rb
+++ b/app/models/core/verifier.rb
@@ -1,0 +1,4 @@
+module Core
+  class Verifier < Core::Base
+  end
+end

--- a/app/models/query/base.rb
+++ b/app/models/query/base.rb
@@ -1,0 +1,6 @@
+module Query
+  class Base < ActiveRecord::Base
+    self.abstract_class = true
+    establish_connection(AACT::Application::AACT_QUERY_DATABASE_URL)
+  end
+end

--- a/app/views/archive/archive.html.erb
+++ b/app/views/archive/archive.html.erb
@@ -1,7 +1,5 @@
-<div class="wrap">
-  <div class="basicHero">
+<div >
     <h1>AACT Archive (before November 15, 2021)</h1>
-  </div>
 </div>
 
 <section class='learnMore'>
@@ -14,15 +12,6 @@
       </p>
       <%= fa_icon('database') %>
     </a>
-
-    <a href='/archive/data_dictionary' class='learnMoreCard'>
-      <h3>Data Dictionary</h3>
-      <p>
-       Access detailed information about all Archive AACT data elements and how they relate to ClinicalTrials.gov information and corresponding definitions from the National Library or Medicine’s data definitions.
-      </p>
-      <%= fa_icon('graduation-cap') %>
-    </a>
-
     <a href='/archive/download' class='learnMoreCard'>
       <h3>Download AACT</h3>
       <p>

--- a/app/views/archive/download.html.erb
+++ b/app/views/archive/download.html.erb
@@ -1,11 +1,9 @@
-<div class="wrap">
+<div>
 
-  <div class="basicHero">
     <h1>Download Archive AACT</h1>
        <p>
-       The archived <a href='/snapshots'>copies</a> are available for download. These can be used to create a local copy of a particular instance of the database. A number of query and analytic tools (such as SAS, pgAdmin & R) can then be used to connect to and query your local copy.</p>
-       <p>For those who prefer to access the data via simple flat files, static copies are also available as a <a href='/pipe_files'>zipped package of pipe-delimited files</a>.<p>
-  </div>
+       The archived copies are available for download. These can be used to create a local copy of a particular instance of the database. A number of query and analytic tools (such as SAS, pgAdmin & R) can then be used to connect to and query your local copy.</p>
+       <p>For those who prefer to access the data via simple flat files, static copies are also available as a zipped package of pipe-delimited files.<p>
 
   <section class="downloadAact">
      <div class="downloadTypes">

--- a/app/views/archive/schema.html.erb
+++ b/app/views/archive/schema.html.erb
@@ -1,8 +1,6 @@
-<div class="wrap">
+<div>
 
-  <div class="basicHero">
     <h1>AACT Archive Database Schema</h1>
-  </div>
 
   <p>The diagram below illustrates how ClinicalTrials.gov data are stored in the AACT database; it identifies all tables/columns and relationships.</p>
   <p>Each table includes the unique identifier assigned by ClinicalTrials.gov: <i>nct_id</i>. This provides a way to find all data about a particular study and serves as the key that joins related information across multiple tables. Every table (except Studies) also includes an <i>id</i> column which uniquely identifies each row in the table. In most cases, you need to use the <i>nct_id</i> to join tables. For more information about the <i>id</i> column, please refer to the documentation found <a href='/schema#idInformation'>here.</a></p>

--- a/app/views/dictionary/_table_dictionary.html.erb
+++ b/app/views/dictionary/_table_dictionary.html.erb
@@ -1,6 +1,6 @@
 <section id='tableDictionary' class='tableDictionary'>
 <main>
-  <h2>AACT Tables</h2>
+  <h3>AACT Tables</h3>
 
   <p>The list below describes the <%= @tables.size %> study-related tables in the AACT database and provides current row counts for each. Project tables are also defined at the bottom of this table.</p>
 

--- a/app/views/dictionary/_view_dictionary.html.erb
+++ b/app/views/dictionary/_view_dictionary.html.erb
@@ -1,6 +1,6 @@
 <section id='allViewDictionary' class='tableDictionary'>
 <main>
-  <h2>AACT Views & Functions</h2>
+  <h3>AACT Views & Functions</h3>
 
   <p>Database views & functions have been provided to facilitate data retrieval. These features are described below. The first table identifies a set of views that provide concatenate sets of values per study. These views are useful for people who need to generate a spreadsheet that contains one row per study and would like to include info for which studies often have multiple values, such as conditions. For example, if you need a comma-separated list of the conditions associated with a study, you may get that from the all_conditions view. These views are in the ctgov schema; all include 2 columns: NCT_ID & Names. </p>
   <p>Here is a sample query:</p>

--- a/app/views/dictionary/show.html.erb
+++ b/app/views/dictionary/show.html.erb
@@ -12,7 +12,7 @@
       <p>Click <a href='#tableDictionary'>here</a> to view a listing of all <%= @tables.size %> tables with description and row counts. Detailed information about all data elements included in these tables can be found in the data dictionary below.</p>
     </section>
 
-    <h2>AACT Data Elements</h2>
+    <h3>AACT Data Elements</h3>
     <%= render 'data_dictionary_instructions' %>
       <div id="jsGrid" data-schema="ctgov"></div>
     <%= render 'table_dictionary' %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -8,23 +8,21 @@
 
     <thead>
       <tr>
-        <th>Date Created</th>
+        <th>Started</th>
         <th>Event Type</th>
         <th>Status</th>
         <th>Description</th>
-        <th>Details Link</th>
-        <th colspan="5"></th>
+        <th colspan="4"></th>
       </tr>
     </thead>
 
     <tbody>
       <% @load_events.each do |loadevent| %>
         <tr>
-          <td><%= loadevent.created_at.strftime('%m/%d/%Y %l:%M %p') %></td>
+          <td><%= link_to loadevent.created_at.strftime('%m/%d/%Y %l:%M %p'), event_path(loadevent) %></td>
           <td><%= loadevent.event_type %></td>
           <td><%= loadevent.status %></td>
           <td><%= loadevent.description %></td>
-          <td><%= link_to loadevent.id, event_path(loadevent) %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,34 @@
+<div class="container">
+
+  <div class="pb-3">
+    <h1>Load Events</h1>
+  </div>
+
+  <table class="table table-sm table-striped" style="max-width: 100rem;">
+
+    <thead>
+      <tr>
+        <th>Date Created</th>
+        <th>Event Type</th>
+        <th>Status</th>
+        <th>Description</th>
+        <th>Details Link</th>
+        <th colspan="5"></th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <% @load_events.each do |loadevent| %>
+        <tr>
+          <td><%= loadevent.created_at.strftime('%m/%d/%Y %l:%M %p') %></td>
+          <td><%= loadevent.event_type %></td>
+          <td><%= loadevent.status %></td>
+          <td><%= loadevent.description %></td>
+          <td><%= link_to loadevent.id, event_path(loadevent) %></td>
+        </tr>
+      <% end %>
+    </tbody>
+
+  </table>
+
+</div>

--- a/app/views/includes/_main_footer.html.erb
+++ b/app/views/includes/_main_footer.html.erb
@@ -1,5 +1,5 @@
 <!-- Footer -->
-<footer class="text-center">
+<footer class="text-center footer">
   <!-- Links -->
   <div class="footerBar p-2">
     <div class="row justify-content-md-center">

--- a/app/views/includes/_main_header.html.erb
+++ b/app/views/includes/_main_header.html.erb
@@ -7,9 +7,10 @@
       Admin
     </a>
 <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-  <li><a class="dropdown-item"><%= link_to "Notifcation", admin_notices_path%></a></li>
+  <li><a class="dropdown-item"><%= link_to "Notifications", admin_notices_path%></a></li>
   <li><a class="dropdown-item"><%= link_to "Releases", releases_path %></a></li>
   <li><a class="dropdown-item"><%= link_to "Summary", summary_aact_path %></a></li>
+  <li><a class="dropdown-item"><%= link_to "Users", users_path %></a></li>
   <li><hr class="dropdown-divider"></li>
   <li><a class="dropdown-item user-info"><%= link_to "Edit Profile", edit_user_registration_path %>&nbsp;&nbsp;</li>
   <li><a class="dropdown-item user-info"><%= link_to "Sign out", edit_user_registration_path('sign-out'), :id => current_user %></a></li>

--- a/app/views/includes/_main_header.html.erb
+++ b/app/views/includes/_main_header.html.erb
@@ -1,9 +1,16 @@
 <div id='navbar-top' class="navbar navbar-top">
 
-  <% if user_signed_in? %>
+  <% if user_signed_in? and current_user.admin? %>
 
       <p class='user-logged-in'>logged in as <%= current_user.full_name %></p>
     <p class='user-info'>
+    <%= link_to "Edit Profile", edit_user_registration_path %>&nbsp;&nbsp;
+    <%= link_to "Sign out", edit_user_registration_path('sign-out'), :id => current_user %>
+    <%= link_to "Edit Releases", edit_release_path('Edit'), :id => releases_path %>
+    <%= link_to "Summary", summary_aact_path %>
+    <% elsif user_signed_in? %>
+      <p class='user-logged-in'>logged in as <%= current_user.full_name %></p>
+    <p class='user-info'>    
         <%= link_to "Edit Profile", edit_user_registration_path %>&nbsp;&nbsp;
         <%= link_to "Sign out", edit_user_registration_path('sign-out'), :id => current_user %>
     </p>
@@ -13,6 +20,11 @@
         <%= link_to "Sign in", new_user_session_path, class: 'btn' %>
     </p>
   <% end %>
+
+
+
+
+
 </div>
 
 <nav class="navbar navbar-expand-lg">

--- a/app/views/includes/_main_header.html.erb
+++ b/app/views/includes/_main_header.html.erb
@@ -1,13 +1,20 @@
 <div id='navbar-top' class="navbar navbar-top">
 
-  <% if user_signed_in? and current_user.admin? %>
-
+<% if user_signed_in? and current_user.admin? %>
       <p class='user-logged-in'>logged in as <%= current_user.full_name %></p>
-    <p class='user-info'>
-    <%= link_to "Edit Profile", edit_user_registration_path %>&nbsp;&nbsp;
-    <%= link_to "Sign out", edit_user_registration_path('sign-out'), :id => current_user %>
-    <%= link_to "Edit Releases", edit_release_path('Edit'), :id => releases_path %>
-    <%= link_to "Summary", summary_aact_path %>
+  <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      Admin
+    </a>
+<ul class="dropdown-menu" aria-labelledby="navbarDropdown">
+  <li><a class="dropdown-item"><%= link_to "Notifcation", admin_notices_path%></a></li>
+  <li><a class="dropdown-item"><%= link_to "Releases", releases_path %></a></li>
+  <li><a class="dropdown-item"><%= link_to "Summary", summary_aact_path %></a></li>
+  <li><hr class="dropdown-divider"></li>
+  <li><a class="dropdown-item user-info"><%= link_to "Edit Profile", edit_user_registration_path %>&nbsp;&nbsp;</li>
+  <li><a class="dropdown-item user-info"><%= link_to "Sign out", edit_user_registration_path('sign-out'), :id => current_user %></a></li>
+</ul>
+  </li>    
     <% elsif user_signed_in? %>
       <p class='user-logged-in'>logged in as <%= current_user.full_name %></p>
     <p class='user-info'>    
@@ -20,11 +27,6 @@
         <%= link_to "Sign in", new_user_session_path, class: 'btn' %>
     </p>
   <% end %>
-
-
-
-
-
 </div>
 
 <nav class="navbar navbar-expand-lg">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -45,10 +45,11 @@
     <%= render "css_overrides" %>
   </div>
   <% if @should_render_footer != false %>
-    <p><%= render 'includes/circle_buttons' %></p>
+  <p><%= render 'includes/circle_buttons' %></p>
+</body>
     <footer>
       <%= render 'includes/main_footer' %>
     </footer>
   <% end %>
-</body>
+
 </html>

--- a/app/views/pages/_create_db_via_gui.html.erb
+++ b/app/views/pages/_create_db_via_gui.html.erb
@@ -6,6 +6,27 @@
 
   <div id='expand'>
     <p></p>
+     <div>
+    <h4>Current Month's Daily Static Copies</h4>
+      <select class="form-select w-50" aria-label="Default select example" onchange="location = this.value;">
+        <option selected>Select file to download</option>
+        <% @daily.each do |file| %>
+          <option value="<%= file.url%>">
+            <a href=<%= file.url%> download="proposed_file_name"> <%= file.filename%> <%= file.file_size%> GB </a>
+          </option>
+        <% end %>
+      </select>
+
+    <h4 class="mt-3">Monthly Archive of Static Copies</h4>
+      <select class="form-select w-50" aria-label="Default select example" onchange="location = this.value;">
+        <option selected>Select file to download</option>
+        <% @monthly.each do |file| %>
+          <option value="<%= file.url%>">
+            <a href=<%= file.url%> download="proposed_file_name"> <%= file.filename%> <%= file.file_size%> GB </a>
+          </option>
+        <% end %>
+      </select>
+</div>
     <p>PostgreSQL provides helpful instructions on their <a target='_blank' href="https://www.postgresql.org/download">website</a>. For Windows, the certified Interactive Installer by EnterpriseDB is a good option. It includes a graphical interface for PostgreSQL (pgAdmin). The following instructions are for Postgres Version 9.5.4, pgAdmin III, and SQL Shell (psql).</p>
 
     <h4>Using pgAdmin III</h4>
@@ -22,6 +43,7 @@
         <li>In the Restore Options #1 section, under the Don’t save header, select Owner and Privilege and click Restore. </li>
       </ul>
     </ul>
+   
 
     <p>The restore is complete when the Restore database window shows “Process returned exit code 0.”</p>
 
@@ -56,4 +78,5 @@
       <ul class='regularDisplay'>
 
   </div>
+  
 </section>

--- a/app/views/pages/_download_database_specs.html.erb
+++ b/app/views/pages/_download_database_specs.html.erb
@@ -1,6 +1,6 @@
 <section class="learnMore">
 
-  <h4>MeSH Thesaurus</h4>
+  <h3>MeSH Thesaurus</h3>
   <p>All ClinicalTrials.gov data are available in the <i>ctgov</i> schema of the AACT database.</p>
 
   <p>

--- a/app/views/pages/_schema_info.html.erb
+++ b/app/views/pages/_schema_info.html.erb
@@ -1,6 +1,6 @@
 <main>
 <section class="namingConventions">
-  <h3>What were the primary considerations when designing the database?</h3>
+  <h2>What were the primary considerations when designing the database?</h2>
 
    <p>When designing the database, we tried to balance the following objectives:</p>
    <ul class='regularDisplay'>
@@ -37,7 +37,7 @@
 
    <p>While we tried to rigorously adhere to these conventions, reality occasionally failed to cooperate, so compromises were made and exceptions to these rules exist. For example, to limit duplicate verbiage, we preferred the table name <i>References</i> over <i>Study_References</i>, however the word 'References' is a PostgreSQL reserved word and cannot be used as a table name, so <i>Study_References</i> it is.</p>
 
-   <h3 id='arms_groups'>How are arms/groups identified?</h3>
+   <h2 id='arms_groups'>How are arms/groups identified?</h2>
    <p>Considerable thought went into how to present arm and group information to facilitate analysis by simplifying naming and data structures while retaining data fidelity.
 
    NLM defines groups/arms this way:</p>
@@ -145,7 +145,7 @@
       Notice that the integer in the code provided by ClinicalTrials.gov (ctgov_group_code) is often the same for one group across the different result types, but this is not always the case. In the example above, BG000, EG000 & FG000 all represent the 'experimental group', so you're tempted to think that '000' equates to to the 'experimental group' for this study, however for Outcomes, OG000 represents the control group. In short, the number in the ctgov_group_code often links the same group across all result types in a study, but for about 25% of studies, this is not the case, so it can't be counted on to indicate this relationship.
      </p>
 
-   <h3>Information about dates</h3>
+   <h2>Information about dates</h2>
    <p>
    When clinicaltrials.gov started tracking studies, it only tracked the month & year for some fields and not the day for several date values including start date, completion date, primary completion date and verification date. Because day is not provided for some studies, AACT stores these dates in the studies table as character type rather than date type values. Character type dates are of limited utility in an analytic database because they can’t be used to perform standard date calculations such as determining study duration or the average number of months for someone to report results or identify studies registered before/after a certain date.
    </p>
@@ -162,7 +162,7 @@
   </p>
 
     <div id='pending_results'>
-      <h3>Information about dates related to 'pending results'</h3>
+      <h2>Information about dates related to 'pending results'</h2>
       <p>On May 9, 2018, the NLM added a new section of date information to the ClinicalTrials.gov API. The section is labeled "pendng_results" and serves to provide information about result submission activity while the results await quality control review.</p>
 
       <p>NLM provides result submission date(s) for studies that have results awaiting quality control (QC) review. The results themselves are not publicly posted until the review is complete. The dates for three types of events related to results submission are reported in the Pending_Results table:</p>
@@ -184,7 +184,7 @@
     </div>
 
     <div id='trial_sites'>
-      <h3>Information about trial sites (Facilities and Countries)</h3>
+      <h2>Information about trial sites (Facilities and Countries)</h2>
       <p> Information about organizations where the study is/was conducted (aka. facilities, trial sites) is stored in the <i>Facilities</i> table. This represents the facility information that was included in the study record on the date that information was downloaded from ClinicalTrials.gov.</p>
 
       <p>The name and email/phone for the contact person (and optionally, a backup contact) at a facility is available if the facility status (<i>Facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’, and if the data provider has provided such information. This information is stored in AACT in the <i>Facility_Contacts</i> table, which is a ‘child’ of the <i>Facilities</i> table. Facility-level contact information is not required if a central contact has been provided. Contact information is removed from the publicly available content at ClinicalTrials.gov (and therefore from AACT) when the facility is no longer recruiting, or when the overall study status (<i>Studies.overall_status</i>) changes to indicate that the study has completed recruitment.</p>
@@ -199,7 +199,7 @@
     </div>
 
     <div id='delayed_results'>
-      <h3>“Delayed Results” data elements are available in AACT</h3>
+      <h2>“Delayed Results” data elements are available in AACT</h2>
       <p>A responsible party of an applicable clinical trial may delay the deadline for submitting results information to ClinicalTrials.gov for up to two additional years if one of the following two certification conditions applies to the trial:</p>
 
       <ul class='regularDisplay'>

--- a/app/views/pages/_schema_info.html.erb
+++ b/app/views/pages/_schema_info.html.erb
@@ -1,6 +1,6 @@
 <main>
 <section class="namingConventions">
-  <h2>What were the primary considerations when designing the database?</h2>
+  <h3>What were the primary considerations when designing the database?</h3>
 
    <p>When designing the database, we tried to balance the following objectives:</p>
    <ul class='regularDisplay'>
@@ -37,7 +37,7 @@
 
    <p>While we tried to rigorously adhere to these conventions, reality occasionally failed to cooperate, so compromises were made and exceptions to these rules exist. For example, to limit duplicate verbiage, we preferred the table name <i>References</i> over <i>Study_References</i>, however the word 'References' is a PostgreSQL reserved word and cannot be used as a table name, so <i>Study_References</i> it is.</p>
 
-   <h2 id='arms_groups'>How are arms/groups identified?</h2>
+   <h3 id='arms_groups'>How are arms/groups identified?</h3>
    <p>Considerable thought went into how to present arm and group information to facilitate analysis by simplifying naming and data structures while retaining data fidelity.
 
    NLM defines groups/arms this way:</p>
@@ -145,7 +145,7 @@
       Notice that the integer in the code provided by ClinicalTrials.gov (ctgov_group_code) is often the same for one group across the different result types, but this is not always the case. In the example above, BG000, EG000 & FG000 all represent the 'experimental group', so you're tempted to think that '000' equates to to the 'experimental group' for this study, however for Outcomes, OG000 represents the control group. In short, the number in the ctgov_group_code often links the same group across all result types in a study, but for about 25% of studies, this is not the case, so it can't be counted on to indicate this relationship.
      </p>
 
-   <h2>Information about dates</h2>
+   <h3>Information about dates</h3>
    <p>
    When clinicaltrials.gov started tracking studies, it only tracked the month & year for some fields and not the day for several date values including start date, completion date, primary completion date and verification date. Because day is not provided for some studies, AACT stores these dates in the studies table as character type rather than date type values. Character type dates are of limited utility in an analytic database because they can’t be used to perform standard date calculations such as determining study duration or the average number of months for someone to report results or identify studies registered before/after a certain date.
    </p>
@@ -162,7 +162,7 @@
   </p>
 
     <div id='pending_results'>
-      <h2>Information about dates related to 'pending results'</h2>
+      <h3>Information about dates related to 'pending results'</h3>
       <p>On May 9, 2018, the NLM added a new section of date information to the ClinicalTrials.gov API. The section is labeled "pendng_results" and serves to provide information about result submission activity while the results await quality control review.</p>
 
       <p>NLM provides result submission date(s) for studies that have results awaiting quality control (QC) review. The results themselves are not publicly posted until the review is complete. The dates for three types of events related to results submission are reported in the Pending_Results table:</p>
@@ -184,7 +184,7 @@
     </div>
 
     <div id='trial_sites'>
-      <h2>Information about trial sites (Facilities and Countries)</h2>
+      <h3>Information about trial sites (Facilities and Countries)</h3>
       <p> Information about organizations where the study is/was conducted (aka. facilities, trial sites) is stored in the <i>Facilities</i> table. This represents the facility information that was included in the study record on the date that information was downloaded from ClinicalTrials.gov.</p>
 
       <p>The name and email/phone for the contact person (and optionally, a backup contact) at a facility is available if the facility status (<i>Facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’, and if the data provider has provided such information. This information is stored in AACT in the <i>Facility_Contacts</i> table, which is a ‘child’ of the <i>Facilities</i> table. Facility-level contact information is not required if a central contact has been provided. Contact information is removed from the publicly available content at ClinicalTrials.gov (and therefore from AACT) when the facility is no longer recruiting, or when the overall study status (<i>Studies.overall_status</i>) changes to indicate that the study has completed recruitment.</p>
@@ -199,7 +199,7 @@
     </div>
 
     <div id='delayed_results'>
-      <h2>“Delayed Results” data elements are available in AACT</h2>
+      <h3>“Delayed Results” data elements are available in AACT</h3>
       <p>A responsible party of an applicable clinical trial may delay the deadline for submitting results information to ClinicalTrials.gov for up to two additional years if one of the following two certification conditions applies to the trial:</p>
 
       <ul class='regularDisplay'>

--- a/app/views/pages/connect.html.erb
+++ b/app/views/pages/connect.html.erb
@@ -1,10 +1,8 @@
-<div class="wrap">
+<div>
 
-  <div class="basicHero">
     <h1>Connect to AACT</h1>
      <p>As a cloud-hosted PostgreSQL database, AACT can be directly accessed via standard query & analytic tools. Several popular tools, such as pgAdmin and RStudio, are free and relatively easy to install and configure. Other proprietary tools are popular and provide powerful analytic and/or relational database utility; these tools include SAS, Toad, and Tableau. In many cases, access is a matter of installing the software package, configuring it to use PostgreSQL, and providing AACT connection credentials.
      </p>
-  </div>
 
   <section class="connect">
   <div class="connectionTypes">

--- a/app/views/pages/contactus.html.erb
+++ b/app/views/pages/contactus.html.erb
@@ -1,14 +1,13 @@
-<div class="wrap">
+<div>
+  <h1>Contact Us</h1>
   <h4>Status of Issues/Requests</h4>
   <p>If you discover an issue please see if there is a similar issue that we are working on already. If there isn't please fill out the form below and let us know about it.</p>
   <p> If you have an inquiry that is not related to AACT please contact CTTI directly <a href="https://ctti-clinicaltrials.org/contact-us/">here</a>.</p>
   <iframe class="airtable-embed" src="https://airtable.com/embed/shrmhjOdSzZ9WLqd6?backgroundColor=orange&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
   <br>
   <h4>Form to submit Issues/Requests</h4>
-  <iframe class="airtable-embed" src="https://airtable.com/embed/shrsjLUxT5X7Sabi4?backgroundColor=orange" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
-
-
+  <iframe class="airtable-embed" src="https://airtable.com/embed/shrsjLUxT5X7Sabi4?backgroundColor=orange" frameborder="0" onmousewheel="" width="50%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+  
   <div style="display: none;"><%= ENV['PUBLIC_DB_HOST'] %></div>
-
 
 </div>

--- a/app/views/pages/download.html.erb
+++ b/app/views/pages/download.html.erb
@@ -1,11 +1,9 @@
-<div class="wrap">
+<div>
 
-  <div class="basicHero">
     <h1>Download AACT</h1>
        <p>
        A static copy of the AACT database is created on the first of each month. The most recent and archived <a href='/snapshots'>copies</a> are available for download. These can be used to create a local copy of a particular instance of the database. A number of query and analytic tools (such as SAS, pgAdmin & R) can then be used to connect to and query your local copy.</p>
        <p>For those who prefer to access the data via simple flat files, static copies are also available as a <a href='/pipe_files'>zipped package of pipe-delimited files</a>.<p>
-  </div>
 
   <section class="downloadAact">
      <div class="downloadTypes">

--- a/app/views/pages/pgadmin.html.erb
+++ b/app/views/pages/pgadmin.html.erb
@@ -1,15 +1,12 @@
-<div class="wrap">
-  <div class="basicHero">
+<div>
     <h1>Query AACT with pgAdmin</h1>
-  </div>
   <p>
   pgAdmin is a free, reliable, open source graphical query tool that can be used to access any postgreSQL database. A wealth of information about pgAdmin is available on the internet including the <a href='https://www.pgadmin.org/docs/1.22/main.html' target='_blank'>pgAdmin III Documenation Website.</a>  Using pgAdmin necessitates that you install postgreSQL on your local machine, even though you need not download the AACT database to your local machine.  Use of this tool assumes a basic understanding of SQL.
   </p>
 
-</div>
 
 <section class="pgAdmin">
-  <div class="wrap">
+  
 
     <div class="step">
       <span class="stepNumber">1</span>
@@ -98,5 +95,5 @@
     </p>
     <%= image_tag("countresults.png") %>
 
-  </div>
 </section>
+</div>

--- a/app/views/pages/pgadmin.html.erb
+++ b/app/views/pages/pgadmin.html.erb
@@ -5,7 +5,7 @@
   </p>
 
 
-<section class="pgAdmin">
+<section class="pgAdmin container">
   
 
     <div class="step">

--- a/app/views/pages/pipe_files.html.erb
+++ b/app/views/pages/pipe_files.html.erb
@@ -1,9 +1,10 @@
 <section class="pipe-delimited">
-  <h2>Downloading & Using Pipe-Delimited Flat Files</h2>
+  <h1>Pipe-Delimited Flat Files</h1>
+  <h3>Downloading & Using Pipe-Delimited Flat Files</h3>
 
   <p>These instructions are for users who cannot connect to the live PostreSQL database or who want the flexibility of manipulating this information in a raw, conventional text-based format. The flat files can also be used to populate a non-PostgreSQL database. Each set of flat files is created every day from the most current version of the live AACT database. Each daily set of flat files is made available for download until the end of the month. On the first of each month, a permanent copy of the flat files is created, archived and will remain available for download from this website.</p>
 
-  <h2>General information about Flat Files</h2>
+  <h3>General information about Flat Files</h3>
   <ol class='regularDisplay'>
     <li>Structure of Flat Files:  The files were created under a PC environment using UTF-8 encoding. Fields within each file are separated by the vertical bar character (“|”) commonly referred to as a “pipe”. A null or missing value for a field is delineated by consecutive “pipes” in the data stream. Records within each file are delimited by the line feed (LF) character. The first row of each file contains a delimited list of field names and the order of these names indicates the order of the data fields in the flat file. Most fields are character and are not enclosed within quotes, although single or double quotes may appear embedded within many of the descriptive fields.</li>
     <li>Modifications to Source Content to Facilitate Use of Flat Files:  In rare cases, the actual content of the study data contains an embedded pipe (“|”). To prevent software from interpreting the embedded pipe as a delimiter, the entire string containing the pipe has been enclosed in double quotes. Also,line feed and paragraph break characters within fields, which might otherwise be interpreted as end of record characters, have been removed from the flat file database extracts.</li>

--- a/app/views/pages/pipe_files.html.erb
+++ b/app/views/pages/pipe_files.html.erb
@@ -10,7 +10,8 @@
     <li>Modifications to Source Content to Facilitate Use of Flat Files:  In rare cases, the actual content of the study data contains an embedded pipe (“|”). To prevent software from interpreting the embedded pipe as a delimiter, the entire string containing the pipe has been enclosed in double quotes. Also,line feed and paragraph break characters within fields, which might otherwise be interpreted as end of record characters, have been removed from the flat file database extracts.</li>
     <li>Users are encouraged to refer to the Schema Diagram and associated information to determine the relationships between the different data files that comprise AACT. These relationships determine how data sets may be merged together.  There is one flat file for each database table indicated in the Schema Diagram. In addition, flat files containing meta data are available (data_definitions.txt, sanity_checks.txt, statistics.txt) are included. The Data Dictionary provides critical information about datasets and variables, including the expected number of records in a dataset, and the length of each variable.</li>
   </ol>
-
+  </section>
+  <section class="pipe-delimited container">
   <div class="step">
     <span class="stepNumber">1</span>
     <h3 class="stepName">Download Zip File Containing Pipe-Delimited Files</h3>

--- a/app/views/pages/pipe_files_with_r.html.erb
+++ b/app/views/pages/pipe_files_with_r.html.erb
@@ -1,9 +1,10 @@
-  <div class="wrap">
+  <div>
 
     <p></p>
     <h2>Tips for Analyzing Data in Pipe-Delimited Files Using R</h2>
     <p>The pipe-delimited text files can be read using the <i>read.table()</i> function in base R.  R is powerful and can provide a lot of useful information with very little effort (as demonstrated in the instructions below). <i>Note: These instructions were tested using R 3.1.2 installed on a Linux platform.</i></p>
 
+    <section class="container">
     <%= render 'install_r' %>
 
     <div class="step">
@@ -250,5 +251,5 @@ print( sz * 250000 / 1000, units="Gb")   </p>
         </p>
       </pre>
     </p>
-
+    </section>
 </div>

--- a/app/views/pages/pipe_files_with_sas.html.erb
+++ b/app/views/pages/pipe_files_with_sas.html.erb
@@ -1,8 +1,8 @@
-<div class="wrap">
+<div>
   <h2>Tips for Analyzing Data in Pipe-Delimited Files Using SAS</h2>
 
   <p>The text files can be read using in SAS using PROC IMPORT or with a DATA STEP. The DATA STEP is recommended because it allows the user more control over how variables are input (e.g., variable lengths and formats). However PROC IMPORT can provide a useful first pass, and generates explicit DATA STEP code in the SAS log file that can be modified for a second pass run.</p>
-
+<section class="container">
    <div class="step">
      <span class="stepNumber">1</span>
      <h3 class="stepName">Start by Reading a Small File</h3>
@@ -306,5 +306,5 @@
         <span class='command-response'>            outcomes_assessor_masked $</span>
         <span class='command-response'>            ;</span>
         <span class='command-response'>run;</span>
-
+</section>
 </div>

--- a/app/views/pages/points_to_consider.html.erb
+++ b/app/views/pages/points_to_consider.html.erb
@@ -3,11 +3,11 @@
 
 <section class="pointsToConsider">
 
-    <h3>What is AACT?</h3>
+    <h2>What is AACT?</h2>
 
     <p class='ptc'>AACT is the database for Aggregate Analysis of <a target='_blank' href="https://clinicaltrials.gov"  onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">ClinicalTrials.gov</a>. This version of AACT is a PostgreSQL relational database containing information about clinical studies that have been been registered at ClinicalTrials.gov. AACT includes all of the protocol and results data elements for studies that are publicly available at ClinicalTrials.gov. Content is downloaded daily from ClinicalTrials.gov and loaded into AACT.</p>
 
-    <h3>What population of studies is represented in AACT?</h3>
+    <h2>What population of studies is represented in AACT?</h2>
 
     <p class='ptc'>All studies registered and publicly available in ClinicalTrials.gov are included in AACT. The ClinicalTrials.gov was released for the registration of studies on <b>February 29, 2000</b>. The registry accepts interventional studies in which participants are assigned according to a research protocol to receive specific interventions, as well as observational studies. It also includes Expanded Access records which describe the procedure for obtaining an experimental drug or device for patients who are not adequately treated by existing therapy and who are unable to participate in a controlled clinical study.</p>
 
@@ -132,35 +132,35 @@
       <li>Although studies of FDA regulated devices are likely to be registered, the registration records for studies of devices not yet approved or cleared may not be publicly posted until after the device is cleared or approved.</li>
     </ul>
 
-     <h3>Is the information in AACT up-to-date?</h3>
+     <h2>Is the information in AACT up-to-date?</h2>
 
      <p class='ptc'>The AACT database is updated every night at midnight, so the information in AACT is one day behind that which appears in ClinicalTrials.gov. The nightly update process uses the ClinicalTrials.gov RSS feed to identify studies that were added or changed in ClinicalTrials.gov the previous day, and then uses the ClinicalTrials.gov API to retrieve current data for just these studies. Only new/changed studies are created/modified. This process takes about one and a half hours, depending on how many studies were added/changed in ClinicalTrials.gov the previous day.</p>
      <p class='ptc'>Occassionally, studies must be removed from ClinicalTrials.gov, such as those that were accidentally entered twice. The nightly update process does not detect removed studies so once a month, the AACT database is dropped and completely refreshed.</p>
      <p class='ptc'>Both the nightly (incremental) and monthly (full) updates are performed on a 'background' database so that the publicly accessible database remains accessible while updates take place. When the process completes, the updated version is copied to the public database. This 'copy step' takes about 5 minutes, during which time the database is inaccessible. Since the nightly load starts at midnight and takes about one and a half hours, this 5-minute downtime usually occurs sometime between 1am & 2am.</p>
      <p class='ptc'>Please refer to the posted <a target='_blank' href='/update_policy'>update schedule</a> for more details.</p>
 
-     <h3>How are unique studies identified in AACT?</h3>
+     <h2>How are unique studies identified in AACT?</h2>
 
      <p class='ptc'>Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinialTrials.gov refers to a unique clinical study, however a small number of <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>duplicate records may exist in the database.</a></p>
 
-    <h3>How does content in AACT compare to what is in ClinicalTrials.gov?</h3>
+    <h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
 
     <p class='ptc'>AACT includes all protocol and results data for every study that is publicly available at ClinicalTrials.gov. All publicly available content from the current record for a study is included in AACT as it appears in ClinicalTrials.gov. The AACT database preserves the content from the source XML files downloaded from the ClinicalTrials.gov API; content is not cleaned or manipulated in any way. However, to help facilitate queries using AACT, several additional variables derived from the raw content are included in AACT's Calculated_Values table.</p>
     <p class='ptc'>The history of changes to a study record (available at the ClinicalTrials.gov archive site) is not included in the current version of AACT.</p>
 
-    <h3>What types of questions can be investigated using ClinicalTrials.gov data?</h3>
+    <h2>What types of questions can be investigated using ClinicalTrials.gov data?</h2>
 
     <p class='ptc'>The AACT database contains both ‘study protocol’ and ‘results data’ elements. The protocol (or registration) records describe the study characteristics including sponsor, disease condition, type of intervention, participant eligibility, anticipated enrollment, study design, locations, and outcome measures. Summary results data elements including participant flow, baseline characteristics, outcome results, and frequencies of serious and other adverse events are included in AACT.  The <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/'>article by Tse et al</a> may be helpful in understanding the components of the basic results that are reported at ClinicalTrials.gov.</p>
 
-    <h3>How can protocol/registration data be used?</h3>
+    <h2>How can protocol/registration data be used?</h2>
 
     <p class='ptc'>We anticipate that investigators will use the current database to explore the characteristics of selected subsets of clinical studies (e.g., typical enrollment for a phase 3 study in breast cancer patients), and to compare and contrast these characteristics across different subgroups of studies (e.g., sponsor; device versus drug intervention; or prevention versus treatment).</p>
 
-    <h3>How can results and adverse events data be used?</h3>
+    <h2>How can results and adverse events data be used?</h2>
 
     <p class='ptc'>Researchers may be able to use the basic results and adverse events summary data reported at ClinicalTrials.gov for meta-analysis or systematic review (e.g., to compare the efficacy and safety of different types of diabetes therapies).  However, because only a small subset of studies registered at ClinicalTrials.gov are required to report results, the results data from ClinicalTrials.gov will most likely be a useful supplement to traditional data sources used for a meta-analysis or systematic review, such as published and unpublished manuscripts and abstracts, rather than the core data source. Standard techniques for valid meta-analysis or systematic review (e.g., <a target='_blank' href="http://annals.org/article.aspx?articleid=744664">PRISMA statement</a>) should be used when determining how to appropriately identify and aggregate summary data gleaned from ClinicalTrials.gov and/or literature.)</p>
 
-    <h3>How should data elements be interpreted?</h3>
+    <h2>How should data elements be interpreted?</h2>
 
     <p class='ptc'>When interpreting this information, you’re encouraged to refer to the authoritative definitions provided by the National Library of Medicine (NLM). The most recent data element definitions are available on the NLM site for <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>studies</a> and <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results</a> data. Data interpretation may depend on:</p>
     <ul class='regularDisplay'>
@@ -171,7 +171,7 @@
 
     <p class="note">Note that the study record may be updated by the owner of the record at any time. Fields such as enrollment type may be changed from anticipated to actual, indicating that the value entered now reflects the actual rather than the planned enrollment. When data are downloaded, the result is a static copy of the database at that particular time point, and the history of changes made to the field is lost.</p>
 
-    <h3>How complete and accurate are the data?</h3>
+    <h2>How complete and accurate are the data?</h2>
 
     <p class='ptc'>The presence of a record in a table indicates that information was submitted to ClinicalTrials.gov for at least one element in that table before the data were downloaded from ClinicalTrials.gov. Some data elements are more/less likely than others to have missing information, depending on several known factors. For example:</p>
 
@@ -190,11 +190,11 @@
 
     <p class='ptc'>During our own analysis of the ClinicalTrials.gov database, several extreme values for numeric data elements were encountered, such as an anticipated enrollment of several million subjects. Before proceeding with aggregate analysis, users are encouraged to review data distributions in order to select appropriate analysis methods, and to run their own consistency checks (e.g., to compare whether the number of arm descriptions provided for the study matches the data element that quantifies the number of arms in the study design) as needed.</p>
 
-    <h3>Use of appropriate statistical inference</h3>
+    <h2>Use of appropriate statistical inference</h2>
 
     <p class='ptc'>If the AACT results data are to be used to support a meta-analysis or systematic review of the safety or efficacy of a particular intervention, then standard methods of meta-analysis or systematic review (e.g., the <a target='_blank' href="http://annals.org/article.aspx?articleid=744664" onClick="ga('send','event','external link','guide page: PRISMA')">PRISMA statement</a> should be used to appropriately account for study-to-study variability and other sources of uncertainty or bias. We recommend that authors consider the following points when deciding whether to report p-values, confidence intervals, or other probability-based inference when performing aggregate analysis of the ClinicalTrials.gov database:  </p>
 
-    <h3>Is the data-generating mechanism random?</h3>
+    <h2>Is the data-generating mechanism random?</h2>
     <p class='ptc'>Methods of statistical inference such as p-values and 95% confidence intervals are most appropriate when used to quantify the uncertainty of estimates or comparisons due to a random process that generates the data. Examples of such processes include selection of a random sample of subjects from a broader population, randomly assigning a treatment to a cohort of subjects, or a coin toss about which we aim to predict future results.</p>
 
     <p class='ptc'>In the following examples, we recommend against reporting p-values and 95% confidence intervals because the data generating mechanism is not random.</p>
@@ -203,7 +203,7 @@
 
     <p class='ptc'><b>Example 2: </b>Descriptive analysis of the “clinical trials enterprise” as characterized by the studies registered in ClinicalTrials.gov. Despite mandates for study registration <a href="#table1">(Table 1)</a>, it may be that some studies that are required to be registered are not. In this case the sample (studies registered in ClinicalTrials.gov) may not equal the population (clinical trials enterprise). However, it is likely that those studies not registered are not excluded at random, and therefore neither p-values nor confidence intervals are helpful to support extrapolation from the sample to the population. To support such extrapolation, we recommend careful consideration of the studies that are highly likely to be registered (see section above on Population), and to limit inference to this population so that sample-vs-population uncertainty is minimal.</p>
 
-    <h3>How can I objectively identify important differences?</h3>
+    <h2>How can I objectively identify important differences?</h2>
 
     <p class='ptc'>In practice, p-values and confidence intervals are often employed even when there is no random data generating process to highlight differences that are larger than “noise” (e.g., authors may want to highlight differences with a p-value < .001).  While this practice may not have a strong foundation in statistical philosophy, we acknowledge that many audiences (e.g., journal peer reviewers) may demand p-values because they appear to provide objective criteria for identifying larger-than-expected signals in the data.  While we don’t encourage reporting of p-values for this purpose, we do encourage analysts to specify objective criteria for evaluating signals in the data.  Examples are provided:</p>
 
@@ -218,7 +218,7 @@
       <li>To quantify signal to noise, the analyst could calculate a t-statistic or a chi-squared statistic (without the p-value) and rank differences between 2 groups based on these values.  The analyst might pre-specify a threshold (e.g., absolute value of 3) to flag notable differences.</li>
     </ul>
 
-    <h3>Specific tips for working with the AACT database</h3>
+    <h2>Specific tips for working with the AACT database</h2>
 
     <ul class='regularDisplay'>
       <li>Users are encouraged to use the <a href='/schema' target="_blank" onClick="ga('send','event','download','guide page: download schema')">Schema Diagram</a> to determine relationships between different AACT tables. These relationships determine how tables may be linked using tools such as SAS, R & SQL.</li>
@@ -233,7 +233,7 @@
     <p class='ptc'><%= render partial: 'schema_info' %></p>
 
 
-    <h3>References</h3>
+    <h2>References</h2>
 
     <ol>
       <li>Zarin, D. A., Tse, T. T., Williams, R. J., Califf, R. M., and Ide, N. C. (2011). <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article" onClick="ga('send','event','external link','guide page: Zarin 1 ref')">The ClinicalTrials.gov results database – update and key issues</a>. N Engl J Med 364: 852–60.</li>

--- a/app/views/pages/points_to_consider.html.erb
+++ b/app/views/pages/points_to_consider.html.erb
@@ -1,14 +1,13 @@
-<div class="basicHero">
+
   <h1>Researcher's Guide to Using Aggregate Analysis of ClinicalTrials.gov (AACT) Database</h1>
-</div>
 
 <section class="pointsToConsider">
 
-    <h2>What is AACT?</h2>
+    <h3>What is AACT?</h3>
 
     <p class='ptc'>AACT is the database for Aggregate Analysis of <a target='_blank' href="https://clinicaltrials.gov"  onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">ClinicalTrials.gov</a>. This version of AACT is a PostgreSQL relational database containing information about clinical studies that have been been registered at ClinicalTrials.gov. AACT includes all of the protocol and results data elements for studies that are publicly available at ClinicalTrials.gov. Content is downloaded daily from ClinicalTrials.gov and loaded into AACT.</p>
 
-    <h2>What population of studies is represented in AACT?</h2>
+    <h3>What population of studies is represented in AACT?</h3>
 
     <p class='ptc'>All studies registered and publicly available in ClinicalTrials.gov are included in AACT. The ClinicalTrials.gov was released for the registration of studies on <b>February 29, 2000</b>. The registry accepts interventional studies in which participants are assigned according to a research protocol to receive specific interventions, as well as observational studies. It also includes Expanded Access records which describe the procedure for obtaining an experimental drug or device for patients who are not adequately treated by existing therapy and who are unable to participate in a controlled clinical study.</p>
 
@@ -133,35 +132,35 @@
       <li>Although studies of FDA regulated devices are likely to be registered, the registration records for studies of devices not yet approved or cleared may not be publicly posted until after the device is cleared or approved.</li>
     </ul>
 
-     <h2>Is the information in AACT up-to-date?</h2>
+     <h3>Is the information in AACT up-to-date?</h3>
 
      <p class='ptc'>The AACT database is updated every night at midnight, so the information in AACT is one day behind that which appears in ClinicalTrials.gov. The nightly update process uses the ClinicalTrials.gov RSS feed to identify studies that were added or changed in ClinicalTrials.gov the previous day, and then uses the ClinicalTrials.gov API to retrieve current data for just these studies. Only new/changed studies are created/modified. This process takes about one and a half hours, depending on how many studies were added/changed in ClinicalTrials.gov the previous day.</p>
      <p class='ptc'>Occassionally, studies must be removed from ClinicalTrials.gov, such as those that were accidentally entered twice. The nightly update process does not detect removed studies so once a month, the AACT database is dropped and completely refreshed.</p>
      <p class='ptc'>Both the nightly (incremental) and monthly (full) updates are performed on a 'background' database so that the publicly accessible database remains accessible while updates take place. When the process completes, the updated version is copied to the public database. This 'copy step' takes about 5 minutes, during which time the database is inaccessible. Since the nightly load starts at midnight and takes about one and a half hours, this 5-minute downtime usually occurs sometime between 1am & 2am.</p>
      <p class='ptc'>Please refer to the posted <a target='_blank' href='/update_policy'>update schedule</a> for more details.</p>
 
-     <h2>How are unique studies identified in AACT?</h2>
+     <h3>How are unique studies identified in AACT?</h3>
 
      <p class='ptc'>Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinialTrials.gov refers to a unique clinical study, however a small number of <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>duplicate records may exist in the database.</a></p>
 
-    <h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
+    <h3>How does content in AACT compare to what is in ClinicalTrials.gov?</h3>
 
     <p class='ptc'>AACT includes all protocol and results data for every study that is publicly available at ClinicalTrials.gov. All publicly available content from the current record for a study is included in AACT as it appears in ClinicalTrials.gov. The AACT database preserves the content from the source XML files downloaded from the ClinicalTrials.gov API; content is not cleaned or manipulated in any way. However, to help facilitate queries using AACT, several additional variables derived from the raw content are included in AACT's Calculated_Values table.</p>
     <p class='ptc'>The history of changes to a study record (available at the ClinicalTrials.gov archive site) is not included in the current version of AACT.</p>
 
-    <h2>What types of questions can be investigated using ClinicalTrials.gov data?</h2>
+    <h3>What types of questions can be investigated using ClinicalTrials.gov data?</h3>
 
     <p class='ptc'>The AACT database contains both ‘study protocol’ and ‘results data’ elements. The protocol (or registration) records describe the study characteristics including sponsor, disease condition, type of intervention, participant eligibility, anticipated enrollment, study design, locations, and outcome measures. Summary results data elements including participant flow, baseline characteristics, outcome results, and frequencies of serious and other adverse events are included in AACT.  The <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/'>article by Tse et al</a> may be helpful in understanding the components of the basic results that are reported at ClinicalTrials.gov.</p>
 
-    <h2>How can protocol/registration data be used?</h2>
+    <h3>How can protocol/registration data be used?</h3>
 
     <p class='ptc'>We anticipate that investigators will use the current database to explore the characteristics of selected subsets of clinical studies (e.g., typical enrollment for a phase 3 study in breast cancer patients), and to compare and contrast these characteristics across different subgroups of studies (e.g., sponsor; device versus drug intervention; or prevention versus treatment).</p>
 
-    <h2>How can results and adverse events data be used?</h2>
+    <h3>How can results and adverse events data be used?</h3>
 
     <p class='ptc'>Researchers may be able to use the basic results and adverse events summary data reported at ClinicalTrials.gov for meta-analysis or systematic review (e.g., to compare the efficacy and safety of different types of diabetes therapies).  However, because only a small subset of studies registered at ClinicalTrials.gov are required to report results, the results data from ClinicalTrials.gov will most likely be a useful supplement to traditional data sources used for a meta-analysis or systematic review, such as published and unpublished manuscripts and abstracts, rather than the core data source. Standard techniques for valid meta-analysis or systematic review (e.g., <a target='_blank' href="http://annals.org/article.aspx?articleid=744664">PRISMA statement</a>) should be used when determining how to appropriately identify and aggregate summary data gleaned from ClinicalTrials.gov and/or literature.)</p>
 
-    <h2>How should data elements be interpreted?</h2>
+    <h3>How should data elements be interpreted?</h3>
 
     <p class='ptc'>When interpreting this information, you’re encouraged to refer to the authoritative definitions provided by the National Library of Medicine (NLM). The most recent data element definitions are available on the NLM site for <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>studies</a> and <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results</a> data. Data interpretation may depend on:</p>
     <ul class='regularDisplay'>
@@ -172,7 +171,7 @@
 
     <p class="note">Note that the study record may be updated by the owner of the record at any time. Fields such as enrollment type may be changed from anticipated to actual, indicating that the value entered now reflects the actual rather than the planned enrollment. When data are downloaded, the result is a static copy of the database at that particular time point, and the history of changes made to the field is lost.</p>
 
-    <h2>How complete and accurate are the data?</h2>
+    <h3>How complete and accurate are the data?</h3>
 
     <p class='ptc'>The presence of a record in a table indicates that information was submitted to ClinicalTrials.gov for at least one element in that table before the data were downloaded from ClinicalTrials.gov. Some data elements are more/less likely than others to have missing information, depending on several known factors. For example:</p>
 
@@ -191,7 +190,7 @@
 
     <p class='ptc'>During our own analysis of the ClinicalTrials.gov database, several extreme values for numeric data elements were encountered, such as an anticipated enrollment of several million subjects. Before proceeding with aggregate analysis, users are encouraged to review data distributions in order to select appropriate analysis methods, and to run their own consistency checks (e.g., to compare whether the number of arm descriptions provided for the study matches the data element that quantifies the number of arms in the study design) as needed.</p>
 
-    <h2>Use of appropriate statistical inference</h2>
+    <h3>Use of appropriate statistical inference</h3>
 
     <p class='ptc'>If the AACT results data are to be used to support a meta-analysis or systematic review of the safety or efficacy of a particular intervention, then standard methods of meta-analysis or systematic review (e.g., the <a target='_blank' href="http://annals.org/article.aspx?articleid=744664" onClick="ga('send','event','external link','guide page: PRISMA')">PRISMA statement</a> should be used to appropriately account for study-to-study variability and other sources of uncertainty or bias. We recommend that authors consider the following points when deciding whether to report p-values, confidence intervals, or other probability-based inference when performing aggregate analysis of the ClinicalTrials.gov database:  </p>
 
@@ -204,7 +203,7 @@
 
     <p class='ptc'><b>Example 2: </b>Descriptive analysis of the “clinical trials enterprise” as characterized by the studies registered in ClinicalTrials.gov. Despite mandates for study registration <a href="#table1">(Table 1)</a>, it may be that some studies that are required to be registered are not. In this case the sample (studies registered in ClinicalTrials.gov) may not equal the population (clinical trials enterprise). However, it is likely that those studies not registered are not excluded at random, and therefore neither p-values nor confidence intervals are helpful to support extrapolation from the sample to the population. To support such extrapolation, we recommend careful consideration of the studies that are highly likely to be registered (see section above on Population), and to limit inference to this population so that sample-vs-population uncertainty is minimal.</p>
 
-    <h2>How can I objectively identify important differences?</h2>
+    <h3>How can I objectively identify important differences?</h3>
 
     <p class='ptc'>In practice, p-values and confidence intervals are often employed even when there is no random data generating process to highlight differences that are larger than “noise” (e.g., authors may want to highlight differences with a p-value < .001).  While this practice may not have a strong foundation in statistical philosophy, we acknowledge that many audiences (e.g., journal peer reviewers) may demand p-values because they appear to provide objective criteria for identifying larger-than-expected signals in the data.  While we don’t encourage reporting of p-values for this purpose, we do encourage analysts to specify objective criteria for evaluating signals in the data.  Examples are provided:</p>
 
@@ -219,7 +218,7 @@
       <li>To quantify signal to noise, the analyst could calculate a t-statistic or a chi-squared statistic (without the p-value) and rank differences between 2 groups based on these values.  The analyst might pre-specify a threshold (e.g., absolute value of 3) to flag notable differences.</li>
     </ul>
 
-    <h2>Specific tips for working with the AACT database</h2>
+    <h3>Specific tips for working with the AACT database</h3>
 
     <ul class='regularDisplay'>
       <li>Users are encouraged to use the <a href='/schema' target="_blank" onClick="ga('send','event','download','guide page: download schema')">Schema Diagram</a> to determine relationships between different AACT tables. These relationships determine how tables may be linked using tools such as SAS, R & SQL.</li>
@@ -234,7 +233,7 @@
     <p class='ptc'><%= render partial: 'schema_info' %></p>
 
 
-    <h2>References</h2>
+    <h3>References</h3>
 
     <ol>
       <li>Zarin, D. A., Tse, T. T., Williams, R. J., Califf, R. M., and Ide, N. C. (2011). <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article" onClick="ga('send','event','external link','guide page: Zarin 1 ref')">The ClinicalTrials.gov results database – update and key issues</a>. N Engl J Med 364: 852–60.</li>

--- a/app/views/pages/postgres.html.erb
+++ b/app/views/pages/postgres.html.erb
@@ -1,16 +1,10 @@
-<div class="wrap">
-
-  <div class="basicHero">
+<div>
     <h1>Query AACT with pSQL</h1>
-  </div>
 
-</div>
-
-<section class="psqlAccess">
-  <div class="wrap">
     <p>
     The most straight forward way to access the content of ClinicalTrials.gov is by using the free postgreSQL command line query tool, <a target='_blank' href="http://postgresguide.com/utilities/psql.html">pSQL</a>, to connect to and query the AACT database. This tool is part of the PostgreSQL software package that can be downloaded for free from this <a target='_blank' href="https://www.postgresql.org/download/">site</a>. (Note: AACT is an open source project, based entirely on open source tools; the goal is to make this information as freely accessible as possible to everyone who can make use of it.)
-
+    
+    <section class="psqlAccess container">
     <%= render 'install_postgres' %>
 
     <div class="step">
@@ -34,7 +28,5 @@
       </p>
     </pre>
     <p>
-
-  </div>
-
 </section>
+</div>

--- a/app/views/pages/postgres.html.erb
+++ b/app/views/pages/postgres.html.erb
@@ -1,6 +1,5 @@
 <div>
     <h1>Query AACT with pSQL</h1>
-
     <p>
     The most straight forward way to access the content of ClinicalTrials.gov is by using the free postgreSQL command line query tool, <a target='_blank' href="http://postgresguide.com/utilities/psql.html">pSQL</a>, to connect to and query the AACT database. This tool is part of the PostgreSQL software package that can be downloaded for free from this <a target='_blank' href="https://www.postgresql.org/download/">site</a>. (Note: AACT is an open source project, based entirely on open source tools; the goal is to make this information as freely accessible as possible to everyone who can make use of it.)
     

--- a/app/views/pages/r.html.erb
+++ b/app/views/pages/r.html.erb
@@ -1,15 +1,11 @@
-<div class="wrap">
+<div>
 
-  <div class="basicHero">
     <h1>Connect to AACT using R</h1>
-  </div>
 
   <p>'R' is a free, reliable and popular software environment for statistical computing and graphics. It compiles and runs on a wide variety of UNIX platforms, Windows and MacOS.  R provides one of the easiest and cheapest ways to access and analyze the wealth of information in the AACT database.</p>
   <p>You can access the PostgreSQL AACT database in the cloud using 'R' without needing to install PostgreSQL on your local machine.</p>
-</div>
 
-<section class="rAccess">
-  <div class="wrap">
+<section class="rAccess container">
 
     <%= render 'install_r' %>
 
@@ -41,10 +37,10 @@
         <span class='command-prompt'>> </span><span class='command-entry'> print(aact_sample)</span>
       </p>
     </pre>
+    </section>
 
     <h2>Credentials</h2>
     <p>You will need the following information to access the database directly in the cloud.</p>
     <%= render 'credentials/credentials' %>
 
-  </div>
-</section>
+</div>

--- a/app/views/pages/sas.html.erb
+++ b/app/views/pages/sas.html.erb
@@ -1,14 +1,6 @@
-<div class="wrap">
-
-  <div class="basicHero">
+<div>
     <h1>Connect to AACT using SAS</h1>
-
-  </div>
-
-</div>
-
-<section class="sasAccess">
-  <div class="wrap">
+  <section class="sasAccess">
     <p>This method for accessing the AACT database is recommended for SAS users wanting to run analyses or queries using the live database. </p>
 
     <h3>Note:</h3>
@@ -18,6 +10,8 @@
       <li><p>For SAS users without SAS/ACCESS interface to PostgreSQL, the AACT database tables can be downloaded in delimited text file format.  See instructions: “SAS – downloading and working with the delimited text file version of a static copy of the AACT database”.</p></li>
     </ul>
 
+    </section>
+    <section class="sasAccess container">
     <div class="step">
       <span class="stepNumber">1</span>
       <h3 class="stepName">SAS Installation requirements</h3>
@@ -227,5 +221,6 @@ Using the LIBNAME statement in SAS, assign a <i>libref</i> (a shortcut name) to 
     <p>You will need the following information to access the database directly in the cloud.</p>
     <%= render 'credentials/credentials' %>
 
-  </div>
 </section>
+</div>
+

--- a/app/views/pages/sas.html.erb
+++ b/app/views/pages/sas.html.erb
@@ -216,11 +216,11 @@ Using the LIBNAME statement in SAS, assign a <i>libref</i> (a shortcut name) to 
         </p>
       </pre>
     </p>
+    </section>
 
     <h2>Credentials</h2>
     <p>You will need the following information to access the database directly in the cloud.</p>
     <%= render 'credentials/credentials' %>
 
-</section>
 </div>
 

--- a/app/views/pages/snapshots.html.erb
+++ b/app/views/pages/snapshots.html.erb
@@ -17,26 +17,11 @@
     </div>
 
     <p>Download a zip file that contains the AACT database file. With a single command (see below), this file can be used to automatically configure the database & populate it with the clinical trials dataset. The zip file also contains documentation that describes the database at the time the static copy was created. (The download typically takes 3-7 minutes, depending on your network speed.)</p>
+      <h4>Current Month's Daily Static Copies</h4>
+        <p><%= render 'file_archive', :files => @daily_files, type: 'download database' %></p>
 
-    <h4>Current Month's Daily Static Copies</h4>
-      <select class="form-select w-50" aria-label="Default select example" onchange="location = this.value;">
-        <option selected>Select file to download</option>
-        <% @daily.each do |file| %>
-          <option value="<%= file.url%>">
-            <a href=<%= file.url%> download="proposed_file_name"> <%= file.filename%> <%= file.file_size%> GB </a>
-          </option>
-        <% end %>
-      </select>
-
-    <h4 class="mt-3">Monthly Archive of Static Copies</h4>
-      <select class="form-select w-50" aria-label="Default select example" onchange="location = this.value;">
-        <option selected>Select file to download</option>
-        <% @monthly.each do |file| %>
-          <option value="<%= file.url%>">
-            <a href=<%= file.url%> download="proposed_file_name"> <%= file.filename%> <%= file.file_size%> GB </a>
-          </option>
-        <% end %>
-      </select>
+      <h4>Monthly Archive of Static Copies</h4>
+       <p><%= render 'file_archive', :files => @archive_files, type: 'download database' %></p>
 
     <br>
     <hr>
@@ -122,7 +107,12 @@
 
     <p>Confirm the download was successful by logging into the database and perusing the data.</p>
     <p><%= render partial: 'postgres_local_login' %></p>
+    
 
     <p id='createDbViaGui'><%= render 'create_db_via_gui' %></p>
   </div>
 </section>
+
+
+
+

--- a/app/views/pages/snapshots.html.erb
+++ b/app/views/pages/snapshots.html.erb
@@ -1,16 +1,14 @@
 <section class="snapshots">
 
-  <div class="wrap">
-    <div class="basicHero">
       <h1>Create Local Database from Static Copy of AACT</h1>
-    </div>
 
     <p>If you would like to work with the complete set of clinical trials on your own computer... install PostgreSQL locally, download a static copy of the AACT database, and populate a local PostgreSQL AACT database instance with the data. This page provides the instructions.</p>
 
     <p><i>Windows Users:  Click <a href='/install_postgres'>here</a> for step-by-step instructions to install PostgreSQL & create/load a local copy of AACT on a Windows machine.</i></p>
-
+    </section>
+    <section class="snapshots container">
     <%= render 'install_postgres' %>
-
+   
     <div class="step">
       <span class="stepNumber">2</span>
       <h3 class="stepName">Download Package Containing Static Copy of AACT Database</h3>
@@ -109,5 +107,4 @@
     <p><%= render partial: 'postgres_local_login' %></p>
 
     <p id='createDbViaGui'><%= render 'create_db_via_gui' %></p>
-  </div>
 </section>

--- a/app/views/pages/snapshots.html.erb
+++ b/app/views/pages/snapshots.html.erb
@@ -19,22 +19,20 @@
     <p>Download a zip file that contains the AACT database file. With a single command (see below), this file can be used to automatically configure the database & populate it with the clinical trials dataset. The zip file also contains documentation that describes the database at the time the static copy was created. (The download typically takes 3-7 minutes, depending on your network speed.)</p>
 
     <h4>Current Month's Daily Static Copies</h4>
-<table>
-<thead>
-<% @daily.each do |file| %>
-<tr><td><%= file.created_at %></td></tr>
-<% end %>
-</thead>
-</table>
+      <select class="form-select w-50" aria-label="Default select example">
+          <option selected>Select file to download</option>
+        <% @daily.each do |file| %>
+          <option value="#{file.filename}"><%= file.created_at %>  <%= file.file_size %></option>
+      <% end %>
+      </select>
     <h4>Monthly Archive of Static Copies</h4>
 
-<table>
-<thead>
-<% @monthly.each do |file| %>
-<tr><td><%= file.created_at %></td></tr>
-<% end %>
-</thead>
-</table>
+ <select class="form-select w-50" aria-label="Default select example">
+          <option selected>Select file to download</option>
+        <% @monthly.each do |file| %>
+          <option value="#{file.filename}"><%= file.created_at %>  <%= file.file_size %></option>
+      <% end %>
+      </select>
 
     <br>
     <hr>

--- a/app/views/pages/snapshots.html.erb
+++ b/app/views/pages/snapshots.html.erb
@@ -19,10 +19,23 @@
     <p>Download a zip file that contains the AACT database file. With a single command (see below), this file can be used to automatically configure the database & populate it with the clinical trials dataset. The zip file also contains documentation that describes the database at the time the static copy was created. (The download typically takes 3-7 minutes, depending on your network speed.)</p>
 
     <h4>Current Month's Daily Static Copies</h4>
-    <p><%= render 'file_archive', :files => @daily_files, type: 'download database' %></p>
-
+<table>
+<thead>
+<% @daily.each do |file| %>
+<tr><td><%= file.created_at %></td></tr>
+<% end %>
+</thead>
+</table>
     <h4>Monthly Archive of Static Copies</h4>
-    <p><%= render 'file_archive', :files => @archive_files, type: 'download database' %></p>
+
+<table>
+<thead>
+<% @monthly.each do |file| %>
+<tr><td><%= file.created_at %></td></tr>
+<% end %>
+</thead>
+</table>
+
     <br>
     <hr>
     <div>

--- a/app/views/pages/snapshots.html.erb
+++ b/app/views/pages/snapshots.html.erb
@@ -19,19 +19,23 @@
     <p>Download a zip file that contains the AACT database file. With a single command (see below), this file can be used to automatically configure the database & populate it with the clinical trials dataset. The zip file also contains documentation that describes the database at the time the static copy was created. (The download typically takes 3-7 minutes, depending on your network speed.)</p>
 
     <h4>Current Month's Daily Static Copies</h4>
-      <select class="form-select w-50" aria-label="Default select example">
-          <option selected>Select file to download</option>
+      <select class="form-select w-50" aria-label="Default select example" onchange="location = this.value;">
+        <option selected>Select file to download</option>
         <% @daily.each do |file| %>
-          <option value="#{file.filename}"><%= file.created_at %>  <%= file.file_size %></option>
-      <% end %>
+          <option value="<%= file.url%>">
+            <a href=<%= file.url%> download="proposed_file_name"> <%= file.filename%> <%= file.file_size%> GB </a>
+          </option>
+        <% end %>
       </select>
-    <h4>Monthly Archive of Static Copies</h4>
 
- <select class="form-select w-50" aria-label="Default select example">
-          <option selected>Select file to download</option>
+    <h4 class="mt-3">Monthly Archive of Static Copies</h4>
+      <select class="form-select w-50" aria-label="Default select example" onchange="location = this.value;">
+        <option selected>Select file to download</option>
         <% @monthly.each do |file| %>
-          <option value="#{file.filename}"><%= file.created_at %>  <%= file.file_size %></option>
-      <% end %>
+          <option value="<%= file.url%>">
+            <a href=<%= file.url%> download="proposed_file_name"> <%= file.filename%> <%= file.file_size%> GB </a>
+          </option>
+        <% end %>
       </select>
 
     <br>

--- a/app/views/release_notes/index.html.erb
+++ b/app/views/release_notes/index.html.erb
@@ -5,7 +5,7 @@
       <hr/>
       <h3><%= release.title %> <i> (<%= release.released_on.strftime('%B %d, %Y') %>) </i></h3>
       <h5><%= release.subtitle %></h5>
-      <p><%= release.body %></p>
+      <p><%= markdown(release.body) %></p>
 <% end %>
 
 <hr/> <%= render 'release_notes/v6.0.0' %>

--- a/app/views/shared_data/_explanation.html.erb
+++ b/app/views/shared_data/_explanation.html.erb
@@ -1,14 +1,13 @@
 <div>
-
     <h3>Background</h3>
 
-    <p class='projectExplanation'>Since the AACT database was launched in 2010, dozens of researchers have used it to better understand the state of clinical trials. Investigators have used AACT to study 'results reporting trends' to determine how compliant the research community has been with federally mandated regulations. Others have used AACT to find out which conditions & interventions tend to receive the most attention, which appear to be neglected, and how specific types of trials are distributed geographically.</p>
+    <p class=''>Since the AACT database was launched in 2010, dozens of researchers have used it to better understand the state of clinical trials. Investigators have used AACT to study 'results reporting trends' to determine how compliant the research community has been with federally mandated regulations. Others have used AACT to find out which conditions & interventions tend to receive the most attention, which appear to be neglected, and how specific types of trials are distributed geographically.</p>
 
-    <p class='projectExplanation'>Several AACT-based investigations have produced datasets, such as curated sets of condition terms used to identify a particular subset of studies. Providing access to this analytic data allows others interested in similar topics, or those who would like to further analyze or verify the investigations, to benefit and build upon the previous work.</p>
+    <p class=''>Several AACT-based investigations have produced datasets, such as curated sets of condition terms used to identify a particular subset of studies. Providing access to this analytic data allows others interested in similar topics, or those who would like to further analyze or verify the investigations, to benefit and build upon the previous work.</p>
 
     <h3>Shared Data Available in AACT</h3>
-    <p class='projectExplanation'>To facilitate public sharing of curated data resources between AACT users, we're making project datasets available within the AACT database. Each project has its own database schema that encapsulates the curated data the project's principal investigator has shared with us. Users of the live AACT database can query the project data and/or ClinicalTrials.gov data that resides in the main AACT schema: <i>ctgov</i>. They may join data across different schemas. In short, project information is kept structurally separate from ClinicalTrials.gov data, but the information is also integrated within the same database so it can be used in combination with current trial data.</p>
+    <p class=''>To facilitate public sharing of curated data resources between AACT users, we're making project datasets available within the AACT database. Each project has its own database schema that encapsulates the curated data the project's principal investigator has shared with us. Users of the live AACT database can query the project data and/or ClinicalTrials.gov data that resides in the main AACT schema: <i>ctgov</i>. They may join data across different schemas. In short, project information is kept structurally separate from ClinicalTrials.gov data, but the information is also integrated within the same database so it can be used in combination with current trial data.</p>
 
-    <p class='projectExplanation'>The name of each project's database schema is identified in the table below. Click on a row to view more details & access downloadable versions of datasets and data definitions.</p>
+    <p class=''>The name of each project's database schema is identified in the table below. Click on a row to view more details & access downloadable versions of datasets and data definitions.</p>
 
 </div>

--- a/app/views/shared_data/_please_note.html.erb
+++ b/app/views/shared_data/_please_note.html.erb
@@ -1,10 +1,8 @@
 <div class='pleaseNote'>
-
   <h3>Please Note...</h3>
   <ul>
-    <li><p class='projectExplanation'>Project data are available in the <i>live</i> AACT database hosted at aact-db.ctti-clinicaltrials.org. Static copies of the database and pipe-delimited filesets available for download contain only ClinicalTrials.gov data; they do not include project information.</p></li>
-    <li><p class='projectExplanation'>Files containing data element definitions (defining project-specific tables & columns) are available for download for some projects in the 'Other Attachments' section.</p></li>
-    <li><p class='projectExplanation'> Currently, AACT includes analytic information for four AACT-based projects that CTTI determined will likely benefit the largest audience. Many other investigators have analyzed ClinicalTrials.gov data. CTTI intends to continue to add curated & analytic data from past and future research to further enhance this resource.</p></li>
+    <li><p class=''>Project data are available in the <i>live</i> AACT database hosted at aact-db.ctti-clinicaltrials.org. Static copies of the database and pipe-delimited filesets available for download contain only ClinicalTrials.gov data; they do not include project information.</p></li>
+    <li><p class=''>Files containing data element definitions (defining project-specific tables & columns) are available for download for some projects in the 'Other Attachments' section.</p></li>
+    <li><p class=''> Currently, AACT includes analytic information for four AACT-based projects that CTTI determined will likely benefit the largest audience. Many other investigators have analyzed ClinicalTrials.gov data. CTTI intends to continue to add curated & analytic data from past and future research to further enhance this resource.</p></li>
   </ul>
-
 </div>

--- a/app/views/use_cases/index.html.erb
+++ b/app/views/use_cases/index.html.erb
@@ -1,7 +1,6 @@
 <%=  stylesheet_link_tag "use_cases/use_cases" %>
-<div class="wrap">
-
-  <div class="basicHero">
+<div class="">
+  <h1>Use Cases</h1>
 
       <p class='useCaseInvitation'>All are welcome to develop analytic tools, visualizations and websites that use AACT data. Examples of how AACT might be used:</p>
        <ul class='useCaseInvitation'>
@@ -13,7 +12,7 @@
       <p class='useCaseInvitation'>We encourage everyone to share their work and discoveries with the community so that everyone can benefit.</p>
 
   <p align="left" class='regularDisplay'>Disclaimer: The AACT Gallery is provided as a public resource to learn more about how your colleagues have used AACT. The examples do not represent official products of the Clinical Trials Transformation Initiative (CTTI). Any views expressed do not necessarily reflect official views of CTTI or CTTI’s member organizations.</p>
-  </div>
+  
   <div class="useCase">
     <h1 id='galleryHeading'>AACT Gallery</h1>
     <section class="useCases">

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,8 @@ module AACT
     # aact-core database connection
     AACT_CORE_DATABASE_URL  = ENV['AACT_CORE_DATABASE_URL']
 
+    # aact-query database connection
+    AACT_QUERY_DATABASE_URL  = ENV['AACT_QUERY_DATABASE_URL']
+
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,8 +12,12 @@ development: &default
 test:
   encoding: utf8
   adapter: postgresql
+  host: localhost
+  port: 5432
+  username: <%= ENV.fetch('AACT_DB_SUPER_USERNAME', 'ctti') %>
+  password: <%= ENV.fetch('AACT_PASSWORD', '') %>
+  database: aact_admin_test
   # database: aact_admin_test
-  url:  <%= "postgres://#{ENV.fetch('AACT_DB_SUPER_USERNAME','ctti')}@localhost:5432/aact_admin_test" %>
 
 production: &deploy
   encoding: utf8

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,8 @@ Rails.application.routes.draw do
   get 'summary/aact'
 
   namespace :admin do
-    resources :notices 
-      get "/notices/:id/send_notice" => "notices#send_notice"    
+    resources :notices
+      get "/notices/:id/send_notice" => "notices#send_notice"
   end
 
   # Adding these routes connects those requests to the appropriate actions of the errors controller.
@@ -88,4 +88,5 @@ Rails.application.routes.draw do
   resources :attachments
   resources :use_cases
   resources :use_case_attachments
+  resources :events
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 14.1
--- Dumped by pg_dump version 14.1
+-- Dumped from database version 14.2
+-- Dumped by pg_dump version 14.2
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -26,18 +26,6 @@ CREATE SCHEMA ctgov;
 SET default_tablespace = '';
 
 SET default_table_access_method = heap;
-
---
--- Name: ar_internal_metadata; Type: TABLE; Schema: ctgov; Owner: -
---
-
-CREATE TABLE ctgov.ar_internal_metadata (
-    key character varying NOT NULL,
-    value character varying,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
 
 --
 -- Name: attachments; Type: TABLE; Schema: ctgov; Owner: -
@@ -311,15 +299,15 @@ ALTER SEQUENCE ctgov.health_checks_id_seq OWNED BY ctgov.health_checks.id;
 --
 
 CREATE TABLE ctgov.notices (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     body character varying,
     user_id integer,
     title character varying,
     send_emails boolean,
     emails_sent_at timestamp without time zone,
     visible boolean,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
@@ -328,6 +316,7 @@ CREATE TABLE ctgov.notices (
 --
 
 CREATE SEQUENCE ctgov.notices_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -473,13 +462,13 @@ ALTER SEQUENCE ctgov.publications_id_seq OWNED BY ctgov.publications.id;
 --
 
 CREATE TABLE ctgov.releases (
-    id bigint NOT NULL,
+    id integer NOT NULL,
     title character varying,
     subtitle character varying,
     released_on date,
     body text,
-    created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
 );
 
 
@@ -488,6 +477,7 @@ CREATE TABLE ctgov.releases (
 --
 
 CREATE SEQUENCE ctgov.releases_id_seq
+    AS integer
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -866,14 +856,6 @@ ALTER TABLE ONLY ctgov.user_events ALTER COLUMN id SET DEFAULT nextval('ctgov.us
 --
 
 ALTER TABLE ONLY ctgov.users ALTER COLUMN id SET DEFAULT nextval('ctgov.users_id_seq'::regclass);
-
-
---
--- Name: ar_internal_metadata ar_internal_metadata_pkey; Type: CONSTRAINT; Schema: ctgov; Owner: -
---
-
-ALTER TABLE ONLY ctgov.ar_internal_metadata
-    ADD CONSTRAINT ar_internal_metadata_pkey PRIMARY KEY (key);
 
 
 --

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/models/query/base_spec.rb
+++ b/spec/models/query/base_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Query::Base, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/style.md
+++ b/style.md
@@ -1,0 +1,14 @@
+## Primary Heading
+
+color: #26657a
+font-size: 2.2rem;
+
+## Secondary Heading
+
+color: #26657a
+font-size: 1.7rem;
+
+## Normal Text
+
+color: #57585c
+font-size: 1.2rem;


### PR DESCRIPTION
- As a user I want to see the rendered markdown
- As an admin I should see admin menu
- create a page that lists all the load events
- Update aact-admin to use documents for serving snapshots
- standardize the the content shows in pages (width)
- style fixes
- Add a model to be able to access the LoadEvent from aact-admin
- create connection base model for query
- Add a model to be able to access the verifier from aact-admin
- Create a folder for the archive files