### PR TITLE
AACT-399: Create an index page that lists all the data_definitions

### DIFF
--- a/app/controllers/data_definitions_controller.rb
+++ b/app/controllers/data_definitions_controller.rb
@@ -1,0 +1,5 @@
+class DataDefinitionsController < ApplicationController
+  def index
+    @data_definitions = DataDefinition.all
+  end
+end

--- a/app/views/data_definitions/index.html.erb
+++ b/app/views/data_definitions/index.html.erb
@@ -1,0 +1,30 @@
+<div class="container">
+  <div class="pb-3">
+    <h1>Data Definitions</h1>
+  </div>
+  <table class="table table-sm table-striped" style="max-width: 100rem;">
+    <thead>
+      <tr>
+        <th style="text-align: center">db_section</th>
+        <th style="text-align: center">table_name</th>
+        <th style="text-align: center">column_name</th>
+        <th style="text-align: center">data_type</th>
+        <th style="text-align: center">source</th>
+        <th style="text-align: center">nlm_link</th>
+        <th colspan="6"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @data_definitions.each do |data_definition| %>
+        <tr>
+          <td style="text-align: center"><%= data_definition.db_section %></td>
+          <td style="text-align: center"><%= data_definition.table_name %></td>
+          <td style="text-align: center"><%= data_definition.column_name %></td>
+          <td style="text-align: center"><%= data_definition.data_type %></td>
+          <td style="text-align: center"><%= data_definition.source %></td>
+          <td style="text-align: center"><%= data_definition.nlm_link %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get 'data_definitions/index'
+
   get 'file_records/active_url'
 
   get 'query/submit'

--- a/spec/controllers/data_definitions_controller_spec.rb
+++ b/spec/controllers/data_definitions_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe DataDefinitionsController, type: :controller do
+
+  describe "GET #index" do
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end


### PR DESCRIPTION
Created DataDefinitions controller and index action view. Updated routes.rb and added DataDefinitons controller spec test.
<img width="1280" alt="Screen Shot 2022-07-01 at 10 49 02 AM" src="https://user-images.githubusercontent.com/81119399/176951553-7af6fdc7-1066-4125-a9be-0b4c1d3ba789.png">
<img width="1280" alt="Screen Shot 2022-07-01 at 10 50 04 AM" src="https://user-images.githubusercontent.com/81119399/176951565-ffead03a-c4be-4849-ac3b-34105898b0f3.png">
<img width="1280" alt="Screen Shot 2022-07-01 at 11 01 53 AM" src="https://user-images.githubusercontent.com/81119399/176951608-21fa4093-3089-4401-a9a7-2e7eda3f134f.png">

