### PR TITLE
AACT-401: Add edit & update & show actions to the data_definitions controller

### DIFF
--- a/app/controllers/data_definitions_controller.rb
+++ b/app/controllers/data_definitions_controller.rb
@@ -1,5 +1,6 @@
 class DataDefinitionsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
+  before_action :set_data_definition, only: [:edit, :update]
  
   def index
     @data_definitions = DataDefinition.all
@@ -7,6 +8,9 @@ class DataDefinitionsController < ApplicationController
 
   def new
     @data_definition = DataDefinition.new
+  end
+
+  def edit
   end
  
   def create
@@ -19,8 +23,22 @@ class DataDefinitionsController < ApplicationController
       render :new
     end
   end
+
+  def update
+    if @data_definition.update(data_definition_params)
+      flash.notice = "The Data Definition record was updated successfully."
+      redirect_to data_definitions_path
+    else
+      flash.now.alert = @data_definition.errors.full_messages.to_sentence
+      render :edit
+    end
+  end
   
   private
+    def set_data_definition
+      @data_definition = DataDefinition.find(params[:id])
+    end
+
     # Only allow a list of trusted parameters through.
     def data_definition_params
       params.require(:data_definition)

--- a/app/controllers/data_definitions_controller.rb
+++ b/app/controllers/data_definitions_controller.rb
@@ -1,6 +1,6 @@
 class DataDefinitionsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
-  before_action :set_data_definition, only: [:edit, :update]
+  before_action :set_data_definition, only: [:edit, :update, :show]
  
   def index
     @data_definitions = DataDefinition.all
@@ -11,6 +11,9 @@ class DataDefinitionsController < ApplicationController
   end
 
   def edit
+  end
+
+  def show
   end
  
   def create

--- a/app/views/data_definitions/edit.html.erb
+++ b/app/views/data_definitions/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="modal-body">
   <h1>Edit Data Definition</h1>
   <%= render 'form', data_definition: @data_definition %>
-  <%= link_to 'Back', data_definitions_path, :class => "btn btn-primary btn-sm" %>
+  <%= link_to 'Back', data_definition_path, :class => "btn btn-primary btn-sm" %>
 </div>

--- a/app/views/data_definitions/edit.html.erb
+++ b/app/views/data_definitions/edit.html.erb
@@ -1,0 +1,5 @@
+<div class="modal-body">
+  <h1>Edit Data Definition</h1>
+  <%= render 'form', data_definition: @data_definition %>
+  <%= link_to 'Back', data_definitions_path, :class => "btn btn-primary btn-sm" %>
+</div>

--- a/app/views/data_definitions/index.html.erb
+++ b/app/views/data_definitions/index.html.erb
@@ -24,6 +24,7 @@
           <td style="text-align: center"><%= data_definition.data_type %></td>
           <td style="text-align: center"><%= data_definition.source %></td>
           <td style="text-align: center"><%= data_definition.nlm_link %></td>
+          <td><%= link_to 'Edit', edit_data_definition_path(data_definition), :class => "btn btn-primary btn-sm" %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/data_definitions/index.html.erb
+++ b/app/views/data_definitions/index.html.erb
@@ -3,30 +3,30 @@
     <h1>Data Definitions</h1>
     <%= link_to 'New Data Definition', new_data_definition_path, :class => "btn btn-primary btn-sm" %>
   </div>
-  <table class="table table-sm table-striped" style="max-width: 100rem;">
-    <thead>
-      <tr>
-        <th style="text-align: center">db_section</th>
-        <th style="text-align: center">table_name</th>
-        <th style="text-align: center">column_name</th>
-        <th style="text-align: center">data_type</th>
-        <th style="text-align: center">source</th>
-        <th style="text-align: center">nlm_link</th>
-        <th colspan="6"></th>
-      </tr>
-    </thead>
-    <tbody>
-      <% @data_definitions.each do |data_definition| %>
+
+  <div class="">
+    <table class="table table-sm table-striped">
+      <thead>
         <tr>
-          <td style="text-align: center"><%= data_definition.db_section %></td>
-          <td style="text-align: center"><%= data_definition.table_name %></td>
-          <td style="text-align: center"><%= data_definition.column_name %></td>
-          <td style="text-align: center"><%= data_definition.data_type %></td>
-          <td style="text-align: center"><%= data_definition.source %></td>
-          <td style="text-align: center"><%= data_definition.nlm_link %></td>
-          <td><%= link_to 'Edit', edit_data_definition_path(data_definition), :class => "btn btn-primary btn-sm" %></td>
+          <th style="text-align: center">db_section</th>
+          <th style="text-align: center">table_name and column_name</th>
+          <th style="text-align: center">data_type</th>
+          <th style="text-align: center">source</th>
+          <th style="text-align: center">nlm_link</th>
+          <th colspan="5"></th>
         </tr>
-      <% end %>
-    </tbody>
-  </table>
+      </thead>
+      <tbody>
+        <% @data_definitions.each do |data_definition| %>
+          <tr>
+            <td style="text-align: center"><%= link_to data_definition.db_section, data_definition_path(data_definition) %></td>
+            <td style="text-align: center"><%= data_definition.table_name%>.<%= data_definition.column_name %></td>
+            <td style="text-align: center"><%= data_definition.data_type %></td>
+            <td style="text-align: center"><%= data_definition.source %></td>
+            <td style="text-align: center"><%= data_definition.nlm_link %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/app/views/data_definitions/index.html.erb
+++ b/app/views/data_definitions/index.html.erb
@@ -8,8 +8,8 @@
     <table class="table table-sm table-striped">
       <thead>
         <tr>
+          <th style="text-align: center">table_name.column_name</th>
           <th style="text-align: center">db_section</th>
-          <th style="text-align: center">table_name and column_name</th>
           <th style="text-align: center">data_type</th>
           <th style="text-align: center">source</th>
           <th style="text-align: center">nlm_link</th>
@@ -19,8 +19,9 @@
       <tbody>
         <% @data_definitions.each do |data_definition| %>
           <tr>
-            <td style="text-align: center"><%= link_to data_definition.db_section, data_definition_path(data_definition) %></td>
-            <td style="text-align: center"><%= data_definition.table_name%>.<%= data_definition.column_name %></td>
+            <td style="text-align: center"><%= link_to data_definition.table_name, data_definition_path(data_definition) %> .
+                                           <%= link_to data_definition.column_name, data_definition_path(data_definition) %></td>
+            <td style="text-align: center"><%= data_definition.db_section %></td>
             <td style="text-align: center"><%= data_definition.data_type %></td>
             <td style="text-align: center"><%= data_definition.source %></td>
             <td style="text-align: center"><%= data_definition.nlm_link %></td>

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -1,0 +1,36 @@
+<div class="modal-body">
+  <h1>Data Definition</h1>
+  <hr/>
+
+  <div class="container-fluid">
+    <h5><strong>db_section:</strong> &emsp;&emsp;&ensp;&nbsp; <%= @data_definition.db_section %></h5>
+  </div>
+
+  <div class="container-fluid">
+    <h5><strong>table_name:</strong> &emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.table_name %></h5>
+  </div>
+
+  <div class="container-fluid">
+    <h5><strong>column_name:</strong> &emsp;&nbsp; <%= @data_definition.column_name %></h5>
+  </div>
+
+  <div class="container-fluid">
+    <h5><strong>data_type:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.data_type %></h5>
+  </div>
+
+  <div class="container-fluid">
+    <h5><strong>source:</strong> &emsp;&emsp;&emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.source %></h5>
+  </div>
+
+  <div class="container-fluid">
+    <h5><strong>nlm_link:</strong> &emsp;&emsp;&emsp;&ensp;&nbsp; <%= @data_definition.nlm_link %></h5>
+  </div>
+
+  <div class="pb-5">
+  </div>
+
+  <%= link_to 'Back', data_definitions_path, :class => "btn btn-primary btn-sm" %>
+  <div class="pb-3">
+  </div>
+  <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-danger btn-sm" %>
+</div>

--- a/spec/controllers/data_definitions_controller_spec.rb
+++ b/spec/controllers/data_definitions_controller_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe DataDefinitionsController, type: :controller do
-
   describe "GET #index" do
     it "returns http success" do
       get :index
@@ -17,16 +16,54 @@ RSpec.describe DataDefinitionsController, type: :controller do
   end
 
   describe "POST #create" do
-    it "returns http success" do
-      post :create, data_definition: {"db_section"=>"TEST: protocol", 
-                                      "table_name"=>"TEST: studies", 
-                                      "column_name"=>"TEST: source", 
-                                      "data_type"=>"TEST: string", 
-                                      "source"=>"TEST: <clinical_study>.<source>",
-                                      "nlm_link"=>"TEST: https://prsinfo.clinicaltrials.gov/definitions.html"}
+    it "returns http found" do
+      post :create, 
+            data_definition: { db_section: "TEST: protocol",
+                               table_name: "TEST: studies",
+                               column_name: "TEST: source",
+                               data_type: "TEST: string",
+                               source: "TEST: <clinical_study>.<source>",
+                               nlm_link: "TEST: https://prsinfo.clinicaltrials.gov/definitions.html" }
       expect(response).to redirect_to data_definitions_path
       expect(response).to have_http_status(:found)
     end
   end
+
+  # describe "POST #create" do
+  #   it "returns http found" do
+  #     data_def = FactoryBot.create(:data_definition)
+  #     post :create, data_definition: data_def
+  #     # data_def.dig(:db_section, :table_name, :column_name, :data_type, :source, :nlm_link)
+  #     expect(response).to redirect_to data_definitions_path
+  #     expect(response).to have_http_status(:found)
+  #   end
+  # end
+
+  describe "GET #edit" do
+    it "returns http success" do
+      data_def = FactoryBot.create(:data_definition)
+      get :edit, id: data_def.id
+      expect(response).to render_template(:edit)
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "PUT #update" do
+    it "returns http found" do
+      data_def = FactoryBot.create(:data_definition)
+      put :update, id: data_def.id, data_definition: { "db_section"=>"TEST: results" }
+      expect(response).to redirect_to data_definitions_path
+      expect(response).to have_http_status(:found)
+    end
+  end
+
+  # describe "PUT #update" do
+  #   it "returns http success" do
+  #     data_def = FactoryBot.create(:data_definition)
+  #     data_def.update(db_section: "TEST: results")
+  #     # expect(response).to redirect_to data_definitions_path
+  #     expect(response).to have_http_status(:success)
+  #   end
+  # end
 
 end

--- a/spec/controllers/data_definitions_controller_spec.rb
+++ b/spec/controllers/data_definitions_controller_spec.rb
@@ -41,4 +41,13 @@ RSpec.describe DataDefinitionsController, type: :controller do
       expect(response).to have_http_status(:found)
     end
   end
+
+  describe "GET #show" do
+    it "returns http success" do
+      data_def = FactoryBot.create(:data_definition)
+      get :show, id: data_def.id
+      expect(response).to render_template(:show)
+      expect(response).to have_http_status(:success)
+    end
+  end
 end

--- a/spec/controllers/data_definitions_controller_spec.rb
+++ b/spec/controllers/data_definitions_controller_spec.rb
@@ -17,27 +17,12 @@ RSpec.describe DataDefinitionsController, type: :controller do
 
   describe "POST #create" do
     it "returns http found" do
-      post :create, 
-            data_definition: { db_section: "TEST: protocol",
-                               table_name: "TEST: studies",
-                               column_name: "TEST: source",
-                               data_type: "TEST: string",
-                               source: "TEST: <clinical_study>.<source>",
-                               nlm_link: "TEST: https://prsinfo.clinicaltrials.gov/definitions.html" }
+      data_def = FactoryBot.attributes_for(:data_definition)
+      post :create, data_definition: data_def
       expect(response).to redirect_to data_definitions_path
       expect(response).to have_http_status(:found)
     end
   end
-
-  # describe "POST #create" do
-  #   it "returns http found" do
-  #     data_def = FactoryBot.create(:data_definition)
-  #     post :create, data_definition: data_def
-  #     # data_def.dig(:db_section, :table_name, :column_name, :data_type, :source, :nlm_link)
-  #     expect(response).to redirect_to data_definitions_path
-  #     expect(response).to have_http_status(:found)
-  #   end
-  # end
 
   describe "GET #edit" do
     it "returns http success" do
@@ -56,14 +41,4 @@ RSpec.describe DataDefinitionsController, type: :controller do
       expect(response).to have_http_status(:found)
     end
   end
-
-  # describe "PUT #update" do
-  #   it "returns http success" do
-  #     data_def = FactoryBot.create(:data_definition)
-  #     data_def.update(db_section: "TEST: results")
-  #     # expect(response).to redirect_to data_definitions_path
-  #     expect(response).to have_http_status(:success)
-  #   end
-  # end
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,23 +23,12 @@ FactoryBot.define do
     updated_at  { DateTime.now }
  end
 
-  # factory :data_definition do
-  #   db_section { "TEST: protocol" }
-  #   table_name { "TEST: studies" }
-  #   column_name { "TEST: source" }
-  #   data_type { "TEST: string" }
-  #   source { "TEST: <clinical_study>.<source>" }
-  #   nlm_link { "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"}
-  # end
-
   factory :data_definition do
-    { db_section: "TEST: protocol",
-      table_name: "TEST: studies",
-      column_name: "TEST: source",
-      data_type: "TEST: string",
-      source: "TEST: <clinical_study>.<source>",
-      nlm_link: "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"
-    }  
+    db_section { "TEST: protocol" }
+    table_name { "TEST: studies" }
+    column_name { "TEST: source" }
+    data_type { "TEST: string" }
+    source { "TEST: <clinical_study>.<source>" }
+    nlm_link { "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"}
   end
-
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -22,4 +22,24 @@ FactoryBot.define do
     created_at { DateTime.now }
     updated_at  { DateTime.now }
  end
+
+  # factory :data_definition do
+  #   db_section { "TEST: protocol" }
+  #   table_name { "TEST: studies" }
+  #   column_name { "TEST: source" }
+  #   data_type { "TEST: string" }
+  #   source { "TEST: <clinical_study>.<source>" }
+  #   nlm_link { "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"}
+  # end
+
+  factory :data_definition do
+    { db_section: "TEST: protocol",
+      table_name: "TEST: studies",
+      column_name: "TEST: source",
+      data_type: "TEST: string",
+      source: "TEST: <clinical_study>.<source>",
+      nlm_link: "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"
+    }  
+  end
+
 end


### PR DESCRIPTION
Added the edit and update actions to the DataDefinitions controller. Added a link to the edit action in the index view page. Created the form and view page for the edit action. Added the edit and update actions Rspec controller tests.

<img width="1280" alt="Screen Shot 2022-07-15 at 5 23 03 PM" src="https://user-images.githubusercontent.com/81119399/179373933-e8fa2cdb-ea3c-4689-a2c7-df6fec78e031.png">
<img width="1280" alt="Screen Shot 2022-07-16 at 3 09 48 PM" src="https://user-images.githubusercontent.com/81119399/179373955-510a6501-fdc7-46ef-b041-1b4932930822.png">
<img width="1280" alt="Screen Shot 2022-07-16 at 3 10 03 PM" src="https://user-images.githubusercontent.com/81119399/179373957-9a4947a3-76b1-48ca-8153-14e4c1c150b0.png">
<img width="1280" alt="Screen Shot 2022-07-16 at 3 12 01 PM" src="https://user-images.githubusercontent.com/81119399/179373962-4034c143-056d-457d-b778-b9e6d0abfad5.png">
<img width="1280" alt="Screen Shot 2022-07-16 at 3 12 45 PM" src="https://user-images.githubusercontent.com/81119399/179373965-3e1e472b-3c9a-4fba-bb72-2dab56f57bf3.png">
<img width="1280" alt="Screen Shot 2022-07-16 at 3 13 48 PM" src="https://user-images.githubusercontent.com/81119399/179373971-92e1872f-cae2-48c5-9eba-217f8dc3c7c3.png">
<img width="1280" alt="Screen Shot 2022-07-16 at 3 05 57 PM" src="https://user-images.githubusercontent.com/81119399/179373974-01687bd5-c427-4bac-bedc-83a4d4fc65ac.png">

