### PR TITLE
AACT-402: Add delete action to the data definitions controller

### DIFF
--- a/app/controllers/data_definitions_controller.rb
+++ b/app/controllers/data_definitions_controller.rb
@@ -1,6 +1,6 @@
 class DataDefinitionsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :catch_not_found
-  before_action :set_data_definition, only: [:edit, :update, :show]
+  before_action :set_data_definition, only: [:edit, :update, :show, :destroy]
  
   def index
     @data_definitions = DataDefinition.all
@@ -35,6 +35,11 @@ class DataDefinitionsController < ApplicationController
       flash.now.alert = @data_definition.errors.full_messages.to_sentence
       render :edit
     end
+  end
+
+  def destroy
+    @data_definition.destroy
+    redirect_to data_definitions_path, notice: 'The Data Definition record was successfully deleted.'
   end
   
   private

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -15,7 +15,7 @@
       <div>
         <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-primary" %>   
       </div>
-        <%= button_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger", :method => :delete, data: { confirm: 'Are you sure?' } %>
+        <%= link_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger", :method => :delete, data: { confirm: 'Are you sure?' } %>
       <div>
         <%= link_to 'Back', data_definitions_path, :class => "btn btn-primary" %>  
       </div>

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -9,8 +9,8 @@
     <h5><strong>data_type:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.data_type %></h5>
     <h5><strong>source:</strong> &emsp;&emsp;&emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.source %></h5>
     <h5><strong>nlm_link:</strong> &emsp;&emsp;&emsp;&ensp;&nbsp; <%= @data_definition.nlm_link %></h5>
-  
-
+    <div class="pb-5">
+    </div>
     <div class="d-flex justify-content-between w-25">
       <div>
         <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-primary" %>   

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -4,33 +4,43 @@
 
   <div class="container-fluid">
     <h5><strong>db_section:</strong> &emsp;&emsp;&ensp;&nbsp; <%= @data_definition.db_section %></h5>
-  </div>
+  
 
-  <div class="container-fluid">
+  
     <h5><strong>table_name:</strong> &emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.table_name %></h5>
-  </div>
+  
 
-  <div class="container-fluid">
+  
     <h5><strong>column_name:</strong> &emsp;&nbsp; <%= @data_definition.column_name %></h5>
-  </div>
+  
 
-  <div class="container-fluid">
+  
     <h5><strong>data_type:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.data_type %></h5>
-  </div>
+  
 
-  <div class="container-fluid">
+  
     <h5><strong>source:</strong> &emsp;&emsp;&emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.source %></h5>
-  </div>
+  
 
-  <div class="container-fluid">
+  
     <h5><strong>nlm_link:</strong> &emsp;&emsp;&emsp;&ensp;&nbsp; <%= @data_definition.nlm_link %></h5>
   </div>
 
-  <div class="pb-5">
-  </div>
+  <div class="d-flex justify-content-between w-25">
+  <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-primary" %>   
 
-  <%= link_to 'Back', data_definitions_path, :class => "btn btn-primary btn-sm" %>
-  <div class="pb-3">
-  </div>
-  <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-danger btn-sm" %>
+
+<!-- data confirmation not working, need to investigate -->
+<!-- <%= button_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger btn-sm", :method => :delete, data: { confirm: 'Are you sure?' } %> -->
+<!-- <%= link_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger btn-sm", :method => :delete, data: { confirm: 'Are you sure?' } %> -->
+
+
+<%= button_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger", :method => :delete, data: { confirm: 'Are you sure?' } %>
+
+
+<%= link_to 'Back', data_definitions_path, :class => "btn btn-primary" %>  
+
 </div>
+
+</div>  
+ 

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -4,43 +4,22 @@
 
   <div class="container-fluid">
     <h5><strong>db_section:</strong> &emsp;&emsp;&ensp;&nbsp; <%= @data_definition.db_section %></h5>
-  
-
-  
     <h5><strong>table_name:</strong> &emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.table_name %></h5>
-  
-
-  
     <h5><strong>column_name:</strong> &emsp;&nbsp; <%= @data_definition.column_name %></h5>
-  
-
-  
     <h5><strong>data_type:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.data_type %></h5>
-  
-
-  
     <h5><strong>source:</strong> &emsp;&emsp;&emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.source %></h5>
-  
-
-  
     <h5><strong>nlm_link:</strong> &emsp;&emsp;&emsp;&ensp;&nbsp; <%= @data_definition.nlm_link %></h5>
+  
+
+    <div class="d-flex justify-content-between w-25">
+      <div>
+        <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-primary" %>   
+      </div>
+        <%= button_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger", :method => :delete, data: { confirm: 'Are you sure?' } %>
+      <div>
+        <%= link_to 'Back', data_definitions_path, :class => "btn btn-primary" %>  
+      </div>
+    </div>
   </div>
-
-  <div class="d-flex justify-content-between w-25">
-  <%= link_to 'Edit', edit_data_definition_path(@data_definition), :class => "btn btn-primary" %>   
-
-
-<!-- data confirmation not working, need to investigate -->
-<!-- <%= button_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger btn-sm", :method => :delete, data: { confirm: 'Are you sure?' } %> -->
-<!-- <%= link_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger btn-sm", :method => :delete, data: { confirm: 'Are you sure?' } %> -->
-
-
-<%= button_to 'Delete', data_definition_path(@data_definition), :class => "btn btn-danger", :method => :delete, data: { confirm: 'Are you sure?' } %>
-
-
-<%= link_to 'Back', data_definitions_path, :class => "btn btn-primary" %>  
-
-</div>
-
 </div>  
  

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
   <title>AACT Database | Clinical Trials Transformation Initiative</title>
 
   <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
   <%= include_gon %>
   <%= csrf_meta_tags %>
 

--- a/spec/controllers/data_definitions_controller_spec.rb
+++ b/spec/controllers/data_definitions_controller_spec.rb
@@ -50,4 +50,13 @@ RSpec.describe DataDefinitionsController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe "DELETE #destroy" do
+    it "returns http found" do
+      data_def = FactoryBot.create(:data_definition)
+      delete :destroy, id: data_def.id
+      expect(response).to redirect_to data_definitions_path
+      expect(response).to have_http_status(:found)
+    end
+  end
 end


### PR DESCRIPTION
Added a link from the Data Definition show page to delete the Data Definition and redirect to the index action. Updated the edit, delete, and back buttons size and position on the show page.

<img width="1280" alt="Screen Shot 2022-07-27 at 7 07 25 PM" src="https://user-images.githubusercontent.com/81119399/181406399-ab01bb31-b5c9-4610-ae1b-04d4ee888eff.png">
<img width="1280" alt="Screen Shot 2022-07-27 at 7 09 03 PM" src="https://user-images.githubusercontent.com/81119399/181406420-3a7b7ba6-b32c-4fbd-b5e6-8d6d8a8bd27e.png">
<img width="1280" alt="Screen Shot 2022-07-27 at 7 09 25 PM" src="https://user-images.githubusercontent.com/81119399/181406435-228bb124-0dd9-4d22-8acf-0e56ba0c406c.png">
<img width="1280" alt="Screen Shot 2022-07-27 at 7 09 36 PM" src="https://user-images.githubusercontent.com/81119399/181406446-66432873-8156-4fa2-8820-5c9bd8573fc8.png">

