### PR TITLE
AACT-419: Fix the delete button to show a confirmation button

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require flatpickr
-//= require turbolinks
 //= require_tree .
 
 // var options = {

--- a/app/views/releases/index.html.erb
+++ b/app/views/releases/index.html.erb
@@ -1,5 +1,3 @@
-<p id="notice"><%= notice %></p>
-
 <div class="container">
   <div class="pb-3">
     <h1>Releases</h1>
@@ -11,7 +9,6 @@
         <th>Title</th>
         <th>Subtitle</th>
         <th>Released On</th>
-        <th colspan="3"></th>
       </tr>
     </thead>
     <tbody>
@@ -21,8 +18,7 @@
           <td><%= release.subtitle %></td>
           <td><%= release.released_on.strftime('%B %d, %Y') %></td>
           <td><%= link_to 'Edit', edit_release_path(release), :class => "btn btn-primary btn-sm" %></td>
-          <!-- data confirmation not working, need to investigate -->
-          <td><%= button_to 'Delete', release_path(release), :class => "btn btn-danger btn-sm", :method => :delete, data: { confirm: 'Are you sure?' } %></td>
+          <td><%= link_to 'Delete', release_path(release), :class => "btn btn-danger btn-sm", :method => :delete, data: { confirm: 'Are you sure?' } %></td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/releases/show.html.erb
+++ b/app/views/releases/show.html.erb
@@ -1,24 +1,19 @@
 <div class="modal-body">
   <h1>Release</h1>
   <hr/>
-
   <div class="container-fluid">
     <h3><%= @release.title %> <i> (<%= @release.released_on.strftime('%B %d, %Y') %>) </i></h3>
   </div>
-
   <div class="container-fluid">
     <h5><%= @release.subtitle %></h5>
   </div>
-
   <div class="container-fluid">
     <p><%= markdown(@release.body) %></p>
   </div>
-
   <div class="pb-5">
   </div>
-
-  <%= link_to 'Back', releases_path, :class => "btn btn-primary btn-sm" %>
+  <%= link_to 'Edit', edit_release_path(@release), :class => "btn btn-danger btn-sm" %>
   <div class="pb-3">
   </div>
-  <%= link_to 'Edit', edit_release_path(@release), :class => "btn btn-danger btn-sm" %>
+  <%= link_to 'Back', releases_path, :class => "btn btn-primary btn-sm" %>
 </div>

--- a/spec/requests/releases_spec.rb
+++ b/spec/requests/releases_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe "Releases", type: :request do
 
     describe "DELETE /release " do
       it "redirects to the home page if user is not logged in" do
-        expect {delete release_path(id: 15)}.to_not change(Release, :count)  
+        expect {delete release_path(id: 5)}.to_not change(Release, :count)  
         expect(response).to redirect_to root_path
       end
     end


### PR DESCRIPTION
1. Fixed the delete button to show a confirmation button in the Releases index page. 
2. Removed require of flatpickr and turbolinks in the application.js file to fix flatpickr-date field in the Releases form file.
3. Refactored code in the Release show page. 
4. Updated DELETE Release request test in the releases_spec.rb file.

<img width="1280" alt="Screen Shot 2022-07-29 at 3 52 59 PM" src="https://user-images.githubusercontent.com/81119399/181859424-7707dc79-a2e9-46cd-b6b1-41890b13559d.png">
<img width="1280" alt="Screen Shot 2022-07-29 at 3 53 24 PM" src="https://user-images.githubusercontent.com/81119399/181859432-bd120b50-3884-4591-bc60-4602bb30abf2.png">
<img width="1280" alt="Screen Shot 2022-07-29 at 3 53 40 PM" src="https://user-images.githubusercontent.com/81119399/181859438-cb7ea1a1-5539-4f96-b128-2e2f6fbe573a.png">
<img width="1280" alt="Screen Shot 2022-07-29 at 3 54 50 PM" src="https://user-images.githubusercontent.com/81119399/181859444-2769bb09-e804-4166-a476-247a5b68708e.png">
<img width="1280" alt="Screen Shot 2022-07-29 at 4 07 15 PM" src="https://user-images.githubusercontent.com/81119399/181859462-2ba765be-c33a-4d52-ad5e-edb5166d256a.png">


