### PR TITLE
AACT-403: Data for the data dictionary should come from the data_definitions table

### DIFF
--- a/app/controllers/definitions_controller.rb
+++ b/app/controllers/definitions_controller.rb
@@ -4,18 +4,21 @@ class DefinitionsController < ApplicationController
   # *******///********
 
   def index
-
-    json_file=DataDefinition.make_json_file(params[:schema])
-    dataOut = []
-    json_file.each do |row|
-      if !row['table'].nil? and !row['column'].nil?
-        if !filtered?(params) or passes_filter?(row,params)
-          dataOut << row
-        end
-      end
+    data_def_entries = DataDefinition.all
+    data_def_entries = data_def_entries.map do |data_def_entry|
+      {
+        "CTTI note" => data_def_entry.ctti_note,
+        "column" => data_def_entry.column_name,
+        "data type" => data_def_entry.data_type,
+        "db schema" => data_def_entry.db_schema,
+        "db section" => data_def_entry.db_section,
+        "nlm doc" => data_def_entry.nlm_link,
+        "row count" => data_def_entry.row_count,
+        "source" => data_def_entry.source,
+        "table" => data_def_entry.table_name
+      }
     end
-
-    render json: dataOut, root: false
+    render json: data_def_entries
   end
 
   def filtered?(params)


### PR DESCRIPTION
Modified DefinitionsController index action so that the JSON data we return comes from the database table DataDefinition. The JSON data that we return previously came from a json file instead of the database table. 

<img width="1280" alt="Screen Shot 2022-08-04 at 1 04 51 PM" src="https://user-images.githubusercontent.com/81119399/182944746-a80940ce-b329-459c-a9dd-6c9c87ae5ab7.png">

