### PR TITLE
AACT-422: csv file for the data_dictionary

### DIFF
--- a/app/assets/javascripts/dictionary.js
+++ b/app/assets/javascripts/dictionary.js
@@ -27,7 +27,7 @@ $(function() {
               }
                 return $.ajax({
                     type: "GET",
-                    url: `/definitions?schema=${url}`,
+                    url: `/definitions.json?schema=${url}`,
                     data: filter
                 });
             }

--- a/app/controllers/definitions_controller.rb
+++ b/app/controllers/definitions_controller.rb
@@ -2,10 +2,11 @@ class DefinitionsController < ApplicationController
   # *******///********
   # This code uses data dictionary spreadsheet stored on the DO file server
   # *******///********
+  require 'csv'
 
   def index
     data_def_entries = DataDefinition.all
-    data_def_entries = data_def_entries.map do |data_def_entry|
+    @data_def_entries = data_def_entries.map do |data_def_entry|
       {
         "CTTI note" => data_def_entry.ctti_note,
         "column" => data_def_entry.column_name,
@@ -18,7 +19,15 @@ class DefinitionsController < ApplicationController
         "table" => data_def_entry.table_name
       }
     end
-    render json: data_def_entries
+    respond_to do |format|
+      format.csv  do
+        response.headers['Content-Type'] = 'text/csv'
+        response.headers['Content-Disposition'] = "attachment; filename=definitions.csv"
+        render template: "definitions/index.csv.erb"
+      end
+      format.json  { render json: @data_def_entries }
+      format.html { redirect_to root_path }
+    end
   end
 
   def filtered?(params)

--- a/app/views/definitions/index.csv.erb
+++ b/app/views/definitions/index.csv.erb
@@ -1,0 +1,5 @@
+<%- headers = ['CTTI note', 'column', 'data type', 'db schema', 'db section', 'nlm doc', 'row count', 'source', 'table'] -%>
+<%= CSV.generate_line headers -%>
+<%- @data_def_entries.each do |data_def_entry| -%>
+<%= CSV.generate_line([data_def_entry['CTTI note'], data_def_entry['column'], data_def_entry['data type'], data_def_entry['db schema'], data_def_entry['db section'], data_def_entry['nlm doc'], data_def_entry['row count'], data_def_entry['source'], data_def_entry['table']]).html_safe -%>
+<%- end -%>

--- a/app/views/pages/schema.html.erb
+++ b/app/views/pages/schema.html.erb
@@ -22,7 +22,7 @@
       (right click on the resulting page to download)
     </li>
     <li>
-      <a href=<%= @data_dictionary %> target="_blank" onClick="ga('send','event','download','download data dictionary')">excel version of data dictionary</a> 
+      <a href=<%= '/definitions.csv' %> target="_blank" onClick="ga('send','event','download','download data dictionary')">excel version of data dictionary</a> 
       (online searchable version also available <a href='/data_dictionary' target='_blank'>here</a>)
     </li>
     <li><a href=<%= @table_dictionary %> target="_blank" onClick="ga('send','event','download','download data dictionary')">excel version of table definitions</a></li>


### PR DESCRIPTION
Modified DefinitionsController index action so that we can return a csv file in addition to json file. Added a Definitions view file index.csv.erb. 
<img width="1280" alt="Screen Shot 2022-08-10 at 11 28 34 AM" src="https://user-images.githubusercontent.com/81119399/184428050-ff663727-d8db-45d6-8303-186904e86e19.png">

Changed the link in the AACT Database Schema page to point to the definitions.csv for the excel version of the data dictionary link.
<img width="1280" alt="Screen Shot 2022-08-10 at 12 26 41 PM" src="https://user-images.githubusercontent.com/81119399/184428588-3c80e76a-c5a0-436d-829d-af10eeaac6b8.png">

Changed the url in /javascripts/dictionary.js file so that jsGrid gets the data from definitions.json
<img width="1280" alt="Screen Shot 2022-08-10 at 12 43 01 PM" src="https://user-images.githubusercontent.com/81119399/184429054-4582cecb-c7b2-44aa-88ed-03c6391aed20.png">
<img width="1280" alt="Screen Shot 2022-08-12 at 11 48 19 AM" src="https://user-images.githubusercontent.com/81119399/184429080-63a2762c-45f9-438a-99c2-8fa9369e4407.png">
<img width="1280" alt="Screen Shot 2022-08-12 at 11 48 32 AM" src="https://user-images.githubusercontent.com/81119399/184429095-34cb3c40-bb92-4ac9-afac-bc1de27e3cf2.png">


