### PR TITLE
AACT-350 Add documentation on how to register a user in the dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Make sure you've set values for the following environmental variables:
 | `PUBLIC_DB_HOST=<public_host>` | This is the public database hostname used in the connection string to the production [aact-pub](https://aact.ctti-clinicaltrials.org/connect) database. Under most circumstances, we can use `aact-db.ctti-clinicaltrials.org` as the public-host. |
 | `AACT_ALT_PUBLIC_DATABASE_NAME=aact_alt` | This is the AACT alternate public database name that the database superuser will be accessing. It is used to for staging purposes that allows testing of the database before restoring to AACT. |
 | `AACT_CORE_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@[hostname]:[port]/[dbname]>` | Connection string to the aact-core database. This allows us to connect to this database from aact-admin. The postgres-user and postgres-password are the superuser-name and superuser-password that you have created in the postgres database that comes with PostgreSQL. Under most circumstances, we can use `localhost` as the hostname and `5432` as the port. |  
-| `AACT_QUERY_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@[hostname]:[port]/[dbname]>` | Connection string to the production [aact-pub](https://aact.ctti-clinicaltrials.org/connect) database that users query. This allows us to query this database from aact-admin. The postgres-user and postgres-password are the username and password that you have created at `https://aact.ctti-clinicaltrials.org`. Under most circumstances, we can use `aact-db.ctti-clinicaltrials.org` as the hostname and `5432` as the port. |
+| `AACT_QUERY_DATABASE_URL=<postgresql://[postgres-user]:[postgres-password]@[hostname]:[port]/[dbname]>` | Connection string to the production [aact-pub](https://aact.ctti-clinicaltrials.org/connect) database that users query. This allows us to query this database from aact-admin. The postgres-user and postgres-password are the username and password that you have created at `https://aact.ctti-clinicaltrials.org`. Under most circumstances, we can use `aact-db.ctti-clinicaltrials.org` as the hostname and `5432` as the port. | 
+|`PUBLIC_DB_NAME` |This is the public database name that mailcatcher uses name the variable `aact_public`|
+|`PUBLIC_DB_HOST=<public_host>` |This is the public database hostname used in the connection string to the production. We will be using `localhost` for mailcatcher|
 
 These variables should have been set when you setup AACT Core. If any are missing you should add them to where you store your variables (for instance ".bash_profile" or ".zshrc").  
 
@@ -57,6 +59,15 @@ if you run into issues with bundle installing `libv8` and the `rubyracer` on a m
 
 - lastly you'll need to copy the contents from "public/documentation" to "public/static/documentation"
 ***
+
+## Setting Up MailCatcher
+
+Instructions on how to install [mailcatcher](https://mailcatcher.me/)
+
+- Install with the following command in termnial `gem install mailcatcher`
+- Run the command `mailcatcher` in termnial
+- Go to http://127.0.0.1:1080/
+- Use `mailcatcher --help` to see the command line options
 
 ## Workflow
 ### Branches:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,5 +1,5 @@
 Rails.application.configure do
-  host = ENV["APPLICATION_HOST"] || 'localhost'
+  host = ENV["APPLICATION_HOST"] || 'localhost:3000'
   config.cache_classes = false
   config.eager_load = false
   config.consider_all_requests_local = true
@@ -7,12 +7,7 @@ Rails.application.configure do
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
   config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings =  {
-    :address => '127.0.0.1',
-    :port    => '25',
-    :domain  => host
-  }
-
+  config.action_mailer.smtp_settings = { :address => '127.0.0.1', :port => 1025 }
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load
   config.assets.debug = true


### PR DESCRIPTION
- Add instructions to readme to run mailcatcher and variables. Fixed config env development so mailer will run local

![mailcatcher-setup-readme](https://user-images.githubusercontent.com/50157150/184549409-40aef75a-b4a3-4ce8-95b4-87ad9057a524.jpg)
![variable-readme](https://user-images.githubusercontent.com/50157150/184549410-e50d6ab4-449e-4771-8e4a-85594d821f6c.jpg)
