### PR TITLE
AACT-410: Add ctti note to form

### DIFF
--- a/app/controllers/data_definitions_controller.rb
+++ b/app/controllers/data_definitions_controller.rb
@@ -50,7 +50,7 @@ class DataDefinitionsController < ApplicationController
     # Only allow a list of trusted parameters through.
     def data_definition_params
       params.require(:data_definition)
-        .permit(:db_section, :table_name, :column_name, :data_type, :source, :nlm_link)
+        .permit(:db_section, :table_name, :column_name, :data_type, :source, :ctti_note, :nlm_link)
     end
 
     def catch_not_found(e)

--- a/app/views/data_definitions/_form.html.erb
+++ b/app/views/data_definitions/_form.html.erb
@@ -14,44 +14,35 @@
         <%= f.label :db_section %>
         <%= f.text_field :db_section, class: "form-control" %>
       </div>
-  
       <div class="container-fluid">
         <%= f.label :table_name %>
         <%= f.text_field :table_name, class: "form-control" %>
       </div>
-  
       <div class="container-fluid">
         <%= f.label :column_name %>
         <%= f.text_field :column_name, class: "form-control" %>
       </div>
-  
       <div class="container-fluid">
         <%= f.label :data_type %>
         <%= f.text_field :data_type, class: "form-control" %>
       </div>
-
       <div class="container-fluid">
         <%= f.label :source %>
-        <%= f.text_area :source, rows: 5, class: "form-control" %>
+        <%= f.text_area :source, rows: 2, class: "form-control" %>
       </div>
-
       <div class="container-fluid">
         <%= f.label :ctti_note %>
-        <%= f.text_area :ctti_note, rows: 5, class: "form-control" %>
+        <%= f.text_area :ctti_note, rows: 4, class: "form-control" %>
       </div>
-      
       <div class="container-fluid">
         <%= f.label :nlm_link %>
         <%= f.text_field :nlm_link, class: "form-control" %>
       </div>
-  
       <div class="pb-3">
       </div>
-  
       <div class="actions container-fluid">
         <%= f.submit :class => "old-btn"%>
       </div>
-  
       <div class="pb-4">
       </div>
     </div>

--- a/app/views/data_definitions/_form.html.erb
+++ b/app/views/data_definitions/_form.html.erb
@@ -36,6 +36,11 @@
       </div>
 
       <div class="container-fluid">
+        <%= f.label :ctti_note %>
+        <%= f.text_area :ctti_note, rows: 5, class: "form-control" %>
+      </div>
+      
+      <div class="container-fluid">
         <%= f.label :nlm_link %>
         <%= f.text_field :nlm_link, class: "form-control" %>
       </div>

--- a/app/views/data_definitions/index.html.erb
+++ b/app/views/data_definitions/index.html.erb
@@ -12,8 +12,9 @@
           <th style="text-align: center">db_section</th>
           <th style="text-align: center">data_type</th>
           <th style="text-align: center">source</th>
+          <th style="text-align: center">ctti_note</th>
           <th style="text-align: center">nlm_link</th>
-          <th colspan="5"></th>
+          <th colspan="6"></th>
         </tr>
       </thead>
       <tbody>
@@ -24,6 +25,7 @@
             <td style="text-align: center"><%= data_definition.db_section %></td>
             <td style="text-align: center"><%= data_definition.data_type %></td>
             <td style="text-align: center"><%= data_definition.source %></td>
+            <td style="text-align: center"><%= data_definition.ctti_note %></td>
             <td style="text-align: center"><%= data_definition.nlm_link %></td>
           </tr>
         <% end %>

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -8,6 +8,7 @@
     <h5><strong>column_name:</strong> &emsp;&nbsp; <%= @data_definition.column_name %></h5>
     <h5><strong>data_type:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.data_type %></h5>
     <h5><strong>source:</strong> &emsp;&emsp;&emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.source %></h5>
+    <h5><strong>ctti_note:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.ctti_note %></h5>
     <h5><strong>nlm_link:</strong> &emsp;&emsp;&emsp;&ensp;&nbsp; <%= @data_definition.nlm_link %></h5>
     <div class="pb-5">
     </div>

--- a/app/views/data_definitions/show.html.erb
+++ b/app/views/data_definitions/show.html.erb
@@ -1,15 +1,52 @@
 <div class="modal-body">
   <h1>Data Definition</h1>
-  <hr/>
-
   <div class="container-fluid">
-    <h5><strong>db_section:</strong> &emsp;&emsp;&ensp;&nbsp; <%= @data_definition.db_section %></h5>
-    <h5><strong>table_name:</strong> &emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.table_name %></h5>
-    <h5><strong>column_name:</strong> &emsp;&nbsp; <%= @data_definition.column_name %></h5>
-    <h5><strong>data_type:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.data_type %></h5>
-    <h5><strong>source:</strong> &emsp;&emsp;&emsp;&emsp;&nbsp;&nbsp; <%= @data_definition.source %></h5>
-    <h5><strong>ctti_note:</strong> &emsp;&emsp;&emsp;&nbsp; <%= @data_definition.ctti_note %></h5>
-    <h5><strong>nlm_link:</strong> &emsp;&emsp;&emsp;&ensp;&nbsp; <%= @data_definition.nlm_link %></h5>
+    <div class="container">
+      <div class="row row-cols-2">
+        <div class="col">
+          <h5><strong>db_section:</strong></h5>
+        </div>
+        <div class="col">
+          <h5><%= @data_definition.db_section %></h5>
+        </div>
+        <div class="col">
+          <h5><strong>table_name:</strong></h5>
+        </div>
+        <div class="col">
+          <h5><%= @data_definition.table_name %></h5>
+        </div>
+        <div class="col">
+          <h5><strong>column_name:</strong></h5>
+        </div>
+        <div class="col">
+          <h5><%= @data_definition.column_name %></h5>
+        </div>
+        <div class="col">
+          <h5><strong>data_type:</strong></h5>
+        </div>
+        <div class="col">
+          <h5><%= @data_definition.data_type %></h5>
+        </div>
+        <div class="col">
+          <h5><strong>source:</strong></h5>
+        </div>
+        <div class="col-6">
+          <h5><%= @data_definition.source %></h5>
+        </div>
+        <div class="col">
+          <h5><strong>ctti_note:</strong></h5>
+        </div>
+        <div class="col-6">
+          <h5><%= @data_definition.ctti_note %></h5>
+        </div>
+        <div class="col">
+          <h5><strong>nlm_link:</strong></h5>
+        </div>
+        <div class="col">
+          <h5><%= @data_definition.nlm_link %></h5>
+        </div>
+      </div>  
+    </div>  
     <div class="pb-5">
     </div>
     <div class="d-flex justify-content-between w-25">

--- a/spec/requests/data_definitions_spec.rb
+++ b/spec/requests/data_definitions_spec.rb
@@ -44,19 +44,6 @@ RSpec.describe "Data Definitions", type: :request do
       end
     end
 
-    # describe "POST /data_definitions/ with invalid data" do
-    #   it "does not save a new Data Definition or redirects if invalid db_section" do
-    #     data_def_attributes = { data_definition: {db_section: '', table_name: 'AACT', data_type: 'integer', ctti_note: 'Date NLM made study available via their API'} }
-    #     expect { post data_definitions_path, data_def_attributes }.to_not change(DataDefinition, :count)
-    #     expect(response).to render_template(:new)
-    #   end
-    #   it "does not save a new Data Definition or redirects if invalid ctti_note" do
-    #     data_def_attributes = { data_definition: {db_section: 'title', table_name: 'AACT', data_type: 'boolean', ctti_note: ''} }
-    #     expect { post data_definitions_path, data_def_attributes }.to_not change(DataDefinition, :count)
-    #     expect(response).to render_template(:new)
-    #   end
-    # end
-
     describe "PUT /data_definitions/ with valid data" do
       it "updates a Data Definition and redirects to the show page if valid attribute" do
         data_def = FactoryBot.create(:data_definition)
@@ -66,23 +53,6 @@ RSpec.describe "Data Definitions", type: :request do
         expect(response).to redirect_to data_definitions_path
       end
     end
-
-    # describe "PUT /data_definitions/ with invalid data" do
-    #   it "does not update the Data Definition or redirects if invalid table_name" do
-    #     data_def = FactoryBot.create(:data_definition)
-    #     put data_definition_path(data_def.id), data_definition: {table_name: ''}
-    #     data_def.reload
-    #     expect(data_def.table_name).not_to eq('')
-    #     expect(response).to render_template(:edit)
-    #   end
-    #   it "does not update the Data Definition or redirects if invalid data_type" do
-    #     data_def = FactoryBot.create(:data_definition)
-    #     put data_definition_path(data_def.id), data_definition: {data_type: ''}
-    #     data_def.reload
-    #     expect(data_def.data_type).not_to eq('')
-    #     expect(response).to render_template(:edit)
-    #   end
-    # end
 
     describe "DELETE /data_definitions " do
       it "deletes a Data Definition from Data Definitions" do

--- a/spec/requests/data_definitions_spec.rb
+++ b/spec/requests/data_definitions_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe "Data Definitions", type: :request do
+
+    describe "GET /data_definitions" do
+      it "renders the Data Definitions index page" do
+        get data_definitions_path
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /data_definition" do
+      it "renders the Data Definition show page" do
+        data_def = FactoryBot.create(:data_definition)
+        get data_definition_path(id: data_def.id)
+        expect(response).to render_template(:show)
+      end
+      it "redirects to the Data Definitions index page if the Data Definition ID is invalid" do
+        get data_definition_path(id: 5000) # an ID that doesn't exist
+        expect(response).to redirect_to data_definitions_path
+      end
+    end
+
+    describe "GET /data_definitions/new" do
+      it "renders the Data Definitions new page" do
+        get new_data_definition_path
+        expect(response).to render_template(:new)
+      end
+    end
+
+    describe "GET /data_definitions/:id/edit" do
+      it "renders the Data Definitions edit page" do
+        data_def = FactoryBot.create(:data_definition)
+        get edit_data_definition_path(id: data_def.id)
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    describe "POST /data_definitions/ with valid data" do
+      it "saves a new Data Definition and redirects to the show page if valid attributes" do
+        data_def_attributes = { data_definition: {db_section: 'Code the Dream', table_name: 'AACT', data_type: 'string', ctti_note: 'Testing valid data.'} }
+        expect { post data_definitions_path, data_def_attributes }.to change(DataDefinition, :count)
+        expect(response).to redirect_to data_definitions_path
+      end
+    end
+
+    # describe "POST /data_definitions/ with invalid data" do
+    #   it "does not save a new Data Definition or redirects if invalid db_section" do
+    #     data_def_attributes = { data_definition: {db_section: '', table_name: 'AACT', data_type: 'integer', ctti_note: 'Date NLM made study available via their API'} }
+    #     expect { post data_definitions_path, data_def_attributes }.to_not change(DataDefinition, :count)
+    #     expect(response).to render_template(:new)
+    #   end
+    #   it "does not save a new Data Definition or redirects if invalid ctti_note" do
+    #     data_def_attributes = { data_definition: {db_section: 'title', table_name: 'AACT', data_type: 'boolean', ctti_note: ''} }
+    #     expect { post data_definitions_path, data_def_attributes }.to_not change(DataDefinition, :count)
+    #     expect(response).to render_template(:new)
+    #   end
+    # end
+
+    describe "PUT /data_definitions/ with valid data" do
+      it "updates a Data Definition and redirects to the show page if valid attribute" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {ctti_note: 'Testing valid data.'}
+        data_def.reload
+        expect(data_def.ctti_note).to eq('Testing valid data.')
+        expect(response).to redirect_to data_definitions_path
+      end
+    end
+
+    # describe "PUT /data_definitions/ with invalid data" do
+    #   it "does not update the Data Definition or redirects if invalid table_name" do
+    #     data_def = FactoryBot.create(:data_definition)
+    #     put data_definition_path(data_def.id), data_definition: {table_name: ''}
+    #     data_def.reload
+    #     expect(data_def.table_name).not_to eq('')
+    #     expect(response).to render_template(:edit)
+    #   end
+    #   it "does not update the Data Definition or redirects if invalid data_type" do
+    #     data_def = FactoryBot.create(:data_definition)
+    #     put data_definition_path(data_def.id), data_definition: {data_type: ''}
+    #     data_def.reload
+    #     expect(data_def.data_type).not_to eq('')
+    #     expect(response).to render_template(:edit)
+    #   end
+    # end
+
+    describe "DELETE /data_definitions " do
+      it "deletes a Data Definition from Data Definitions" do
+        data_def = FactoryBot.create(:data_definition)
+        expect { delete data_definition_path(data_def.id) }.to change(DataDefinition, :count)
+        expect(response).to redirect_to data_definitions_path
+      end
+    end
+end


### PR DESCRIPTION
- Refactored code in Data Definitions show view file.
- Updated DataDefinitionsController with ctti_note. 
- Created RSpec requests tests for the Data Definitions.

<img width="1280" alt="Screen Shot 2022-09-01 at 2 25 49 PM" src="https://user-images.githubusercontent.com/81119399/188038786-5028fa3e-dfda-47f5-9ae7-6f21dc95d136.png">
<img width="1280" alt="Screen Shot 2022-09-01 at 2 10 01 PM" src="https://user-images.githubusercontent.com/81119399/188038806-c212803d-5f78-40be-89d2-9ebda6a78075.png">
<img width="1280" alt="Screen Shot 2022-09-01 at 2 24 15 PM" src="https://user-images.githubusercontent.com/81119399/188038834-0c331ea4-bb5d-45ec-bfd9-5f42b777f395.png">
<img width="1280" alt="Screen Shot 2022-09-01 at 6 11 48 PM" src="https://user-images.githubusercontent.com/81119399/188038846-4d19e7e1-10c1-4c17-8a1c-b9444d326354.png">
<img width="1280" alt="Screen Shot 2022-09-01 at 6 07 55 PM" src="https://user-images.githubusercontent.com/81119399/188038865-f9b4bcbe-9646-4ad6-a19c-d6afbe7d059e.png">







