### PR TITLE
AACT-416: Add complete column to Events

### DIFF
--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -14,7 +14,7 @@
       <div class="col-3 list-group-item "><%= link_to loadevent.created_at.strftime('%m/%d/%Y %l:%M %p'), event_path(loadevent) %></div>
       <div class="col-2 list-group-item "><%= loadevent.event_type %></div>
       <div class="col-2 list-group-item "><%= loadevent.status %></div>
-      <div class="col-2 list-group-item "><%= loadevent.completed_at %></div>
+      <div class="col-2 list-group-item "><%= loadevent.completed_at&.strftime('%m/%d/%Y %l:%M %p') %></div>
       <div class="col-3 list-group-item text-start"><%= loadevent.description %></div>
     </li>
   <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -6,14 +6,16 @@
     <div class="col-3 list-group-item list-group-item-dark">Started</div>
     <div class="col-2 list-group-item list-group-item-dark">Event Type</div>
     <div class="col-2 list-group-item list-group-item-dark">Status</div>
-    <div class="col-5 list-group-item list-group-item-dark">Description</div>
+    <div class="col-2 list-group-item list-group-item-dark">Completed At</div>
+    <div class="col-3 list-group-item list-group-item-dark">Description</div>
   </li>
   <% @load_events.each do |loadevent| %>
     <li class="row mb-0">
       <div class="col-3 list-group-item "><%= link_to loadevent.created_at.strftime('%m/%d/%Y %l:%M %p'), event_path(loadevent) %></div>
       <div class="col-2 list-group-item "><%= loadevent.event_type %></div>
       <div class="col-2 list-group-item "><%= loadevent.status %></div>
-      <div class="col-5 list-group-item text-start"><%= loadevent.description %></div>
+      <div class="col-2 list-group-item "><%= loadevent.completed_at %></div>
+      <div class="col-3 list-group-item text-start"><%= loadevent.description %></div>
     </li>
   <% end %>
 </ul>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -36,7 +36,7 @@
       <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
       <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
     </li>
-    <% @load_event.verifier.differences.each do |diff| %>
+    <% @load_event.verifier&.differences&.each do |diff| %>
       <% next if (diff['source'].nil?) %>
       <li class="row mb-0">
         <div class="col-2 text-wrap text-break list-group-item"><%= diff['source'] %></div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,38 +1,33 @@
 <div class="modal-body">
   <h1>Event</h1>
   <hr/>
-
   <div class="container-fluid">
     <h5> <strong>Started:</strong> <%= @load_event.created_at.strftime('%m/%d/%Y %l:%M %p') %> </h5>
   </div>
-
   <div class="container-fluid">
     <h5> <strong>Event Type:</strong> <%= @load_event.event_type %> </h5>
   </div>
-
   <div class="container-fluid">
     <h5> <strong>Status:</strong> <%= @load_event.status %></h5>
   </div>
-
+  <div class="container-fluid">
+    <h5> <strong>Completed At:</strong> <%= @load_event.completed_at %></h5>
+  </div>
   <div class="container-fluid">
     <h5> <strong>Description:</strong> <%= markdown(@load_event.description) %></h5>
   </div>
-
   <div class="container-fluid">
     <h5> <strong>Problems:</strong> <%= markdown(@load_event.problems) %></h5>
   </div>
-
   <div class="container-fluid">
     <h5> <strong>Verifier:</strong> </h5>
   </div>
-
   <ul class="list-group ">
     <li class="row mb-0">
       <div class="col-4 text-wrap text-break list-group-item list-group-item-dark"></div>
       <div class="col-4 text-center text-wrap text-break list-group-item list-group-item-dark">Instances</div>
       <div class="col-4 text-center text-wrap text-break list-group-item list-group-item-dark">Unique</div>
     </li>
-
     <li class="row mb-0">
       <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
       <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
@@ -41,7 +36,6 @@
       <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
       <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
     </li>
-
     <% @load_event.verifier.differences.each do |diff| %>
       <% next if (diff['source'].nil?) %>
       <li class="row mb-0">
@@ -54,9 +48,6 @@
       </li>
     <% end %>
   </ul>
-
-  <div class="pb-5">
-  </div>
-
+  <div class="pb-5"></div>
   <%= link_to 'Back', events_path, :class => "btn btn-primary btn-sm" %>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -11,7 +11,7 @@
     <h5> <strong>Status:</strong> <%= @load_event.status %></h5>
   </div>
   <div class="container-fluid">
-    <h5> <strong>Completed At:</strong> <%= @load_event.completed_at %></h5>
+    <h5> <strong>Completed At:</strong> <%= @load_event.completed_at&.strftime('%m/%d/%Y %l:%M %p') %></h5>
   </div>
   <div class="container-fluid">
     <h5> <strong>Description:</strong> <%= markdown(@load_event.description) %></h5>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -9,4 +9,12 @@ RSpec.describe EventsController, type: :controller do
     end
   end
 
+  describe "GET #show" do
+    it "returns http success" do
+      test_event = FactoryBot.create(:event)
+      get :show, id: test_event.id
+      expect(response).to have_http_status(:success)
+    end
+  end
+
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -31,4 +31,13 @@ FactoryBot.define do
     source { "TEST: <clinical_study>.<source>" }
     nlm_link { "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"}
   end
+
+  factory :event, class: Core::LoadEvent do
+    created_at { DateTime.now }
+    event_type { "incremental" }
+    status { "complete" }
+    completed_at { DateTime.now }
+    description { "Clinical Study description" }
+    problems { "Clinical Study problems" }
+  end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Events", type: :request do
+
+    describe "GET /events" do
+      it "renders the Events index page" do
+        get events_path
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /events" do
+      it "renders the Events show page" do
+        test_event = FactoryBot.create(:event)
+        get event_path(id: test_event.id)
+        expect(response).to render_template(:show)
+      end
+      it "redirects to the Events index page if the Event ID is invalid" do
+        get event_path(id: 5000) # an ID that doesn't exist
+        expect(response).to redirect_to events_path
+      end
+    end
+
+end    


### PR DESCRIPTION
Added a Completed At column to the Events. 

<img width="1280" alt="Screen Shot 2022-09-23 at 10 10 55 PM" src="https://user-images.githubusercontent.com/81119399/192362521-fb4f492d-1a3e-489d-b94e-08610405632d.png">
<img width="1280" alt="Screen Shot 2022-09-23 at 10 11 56 PM" src="https://user-images.githubusercontent.com/81119399/192362533-34cc69c0-ac69-424d-806e-5b32a8cbbb9e.png">
<img width="1280" alt="Screen Shot 2022-09-23 at 10 46 24 PM" src="https://user-images.githubusercontent.com/81119399/192362582-0a1a2eef-0f6d-4fc9-b4c3-a6d2f45487be.png">
<img width="1280" alt="Screen Shot 2022-09-23 at 10 52 47 PM" src="https://user-images.githubusercontent.com/81119399/192362618-ef035e30-8093-442f-bc2b-772e3cad8fda.png">

