### PR TITLE
AACT-409: Data Definition validations

### DIFF
--- a/app/models/data_definition.rb
+++ b/app/models/data_definition.rb
@@ -1,5 +1,6 @@
 require 'active_support/all'
 class DataDefinition < ActiveRecord::Base
+  validates :db_section, :table_name, :column_name, :data_type, :source, :ctti_note, presence: true
 
   def self.default_data_definitions
     Roo::Spreadsheet.open("#{Rails.public_path}/documentation/aact_data_definitions.xlsx")

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -29,6 +29,7 @@ FactoryBot.define do
     column_name { "TEST: source" }
     data_type { "TEST: string" }
     source { "TEST: <clinical_study>.<source>" }
+    ctti_note { "TEST: <clinical_study>.<ctti_note>" }
     nlm_link { "TEST: https://prsinfo.clinicaltrials.gov/definitions.html"}
   end
 end

--- a/spec/requests/data_definitions_spec.rb
+++ b/spec/requests/data_definitions_spec.rb
@@ -37,15 +37,48 @@ RSpec.describe "Data Definitions", type: :request do
     end
 
     describe "POST /data_definitions/ with valid data" do
-      it "saves a new Data Definition and redirects to the show page if valid attributes" do
-        data_def_attributes = { data_definition: {db_section: 'Code the Dream', table_name: 'AACT', data_type: 'string', ctti_note: 'Testing valid data.'} }
-        expect { post data_definitions_path, data_def_attributes }.to change(DataDefinition, :count)
+      it "saves a new Data Definition and redirects to the index page if valid attributes" do
+        data_def = FactoryBot.attributes_for(:data_definition)
+        expect { post data_definitions_path, data_definition: data_def }.to change(DataDefinition, :count)
         expect(response).to redirect_to data_definitions_path
+      end
+    end
+    
+    describe "POST /data_definitions/ with invalid data" do
+      it "does not save a new Data Definition and renders the new page if invalid attribute (blank db_section)" do
+        data_def = FactoryBot.attributes_for(:data_definition, db_section: '')
+        expect { post data_definitions_path, data_definition: data_def }.to_not change(DataDefinition, :count)
+        expect(response).to render_template(:new)
+      end
+      it "does not save a new Data Definition and renders the new page if invalid attribute (blank table_name)" do
+        data_def = FactoryBot.attributes_for(:data_definition, table_name: '')
+        expect { post data_definitions_path, data_definition: data_def }.to_not change(DataDefinition, :count)
+        expect(response).to render_template(:new)
+      end
+      it "does not save a new Data Definition and renders the new page if invalid attribute (blank column_name)" do
+        data_def = FactoryBot.attributes_for(:data_definition, column_name: '')
+        expect { post data_definitions_path, data_definition: data_def }.to_not change(DataDefinition, :count)
+        expect(response).to render_template(:new)
+      end
+      it "does not save a new Data Definition and renders the new page if invalid attribute (blank data_type)" do
+        data_def = FactoryBot.attributes_for(:data_definition, data_type: '')
+        expect { post data_definitions_path, data_definition: data_def }.to_not change(DataDefinition, :count)
+        expect(response).to render_template(:new)
+      end
+      it "does not save a new Data Definition and renders the new page if invalid attribute (blank source)" do
+        data_def = FactoryBot.attributes_for(:data_definition, source: '')
+        expect { post data_definitions_path, data_definition: data_def }.to_not change(DataDefinition, :count)
+        expect(response).to render_template(:new)
+      end
+      it "does not save a new Data Definition and renders the new page if invalid attribute (blank ctti_note)" do
+        data_def = FactoryBot.attributes_for(:data_definition, ctti_note: '')
+        expect { post data_definitions_path, data_definition: data_def }.to_not change(DataDefinition, :count)
+        expect(response).to render_template(:new)
       end
     end
 
     describe "PUT /data_definitions/ with valid data" do
-      it "updates a Data Definition and redirects to the show page if valid attribute" do
+      it "updates a Data Definition and redirects to the index page if valid attribute" do
         data_def = FactoryBot.create(:data_definition)
         put data_definition_path(data_def.id), data_definition: {ctti_note: 'Testing valid data.'}
         data_def.reload
@@ -54,8 +87,53 @@ RSpec.describe "Data Definitions", type: :request do
       end
     end
 
+    describe "PUT /data_definitions/ with invalid data" do
+      it "does not update a Data Definition and renders the edit page if invalid attribute (blank db_section)" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {db_section: ''}
+        data_def.reload
+        expect(data_def.db_section).to_not eq('')
+        expect(response).to render_template(:edit)
+      end
+      it "does not update a Data Definition and renders the edit page if invalid attribute (blank table_name)" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {table_name: ''}
+        data_def.reload
+        expect(data_def.table_name).to_not eq('')
+        expect(response).to render_template(:edit)
+      end
+      it "does not update a Data Definition and renders the edit page if invalid attribute (blank column_name)" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {column_name: ''}
+        data_def.reload
+        expect(data_def.column_name).to_not eq('')
+        expect(response).to render_template(:edit)
+      end
+      it "does not update a Data Definition and renders the edit page if invalid attribute (blank data_type)" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {data_type: ''}
+        data_def.reload
+        expect(data_def.data_type).to_not eq('')
+        expect(response).to render_template(:edit)
+      end
+      it "does not update a Data Definition and renders the edit page if invalid attribute (blank source)" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {source: ''}
+        data_def.reload
+        expect(data_def.source).to_not eq('')
+        expect(response).to render_template(:edit)
+      end
+      it "does not update a Data Definition and renders the edit page if invalid attribute (blank ctti_note)" do
+        data_def = FactoryBot.create(:data_definition)
+        put data_definition_path(data_def.id), data_definition: {ctti_note: ''}
+        data_def.reload
+        expect(data_def.ctti_note).to_not eq('')
+        expect(response).to render_template(:edit)
+      end
+    end
+
     describe "DELETE /data_definitions " do
-      it "deletes a Data Definition from Data Definitions" do
+      it "deletes a Data Definition from Data Definitions and redirects to the index page" do
         data_def = FactoryBot.create(:data_definition)
         expect { delete data_definition_path(data_def.id) }.to change(DataDefinition, :count)
         expect(response).to redirect_to data_definitions_path


### PR DESCRIPTION
Added validations to the DataDefinition model: 
<img width="1280" alt="Screen Shot 2022-09-26 at 8 34 04 PM" src="https://user-images.githubusercontent.com/81119399/192654397-090ab45b-896d-47ed-8980-8e9d88f834cd.png">
<img width="1280" alt="Screen Shot 2022-09-26 at 8 35 33 PM" src="https://user-images.githubusercontent.com/81119399/192654406-8d831493-999c-42da-ade5-098801cd802e.png">
<img width="1280" alt="Screen Shot 2022-09-26 at 8 36 20 PM" src="https://user-images.githubusercontent.com/81119399/192654409-ceaf72fb-e141-4ade-8682-1b3b586216e7.png">
<img width="1280" alt="Screen Shot 2022-09-26 at 8 37 11 PM" src="https://user-images.githubusercontent.com/81119399/192654419-9ffe05de-647b-48a5-b20f-7f156c648783.png">
<img width="1280" alt="Screen Shot 2022-09-26 at 8 37 50 PM" src="https://user-images.githubusercontent.com/81119399/192654608-aa0149e7-0e16-4c82-b52e-303ae5a05402.png">
<img width="1280" alt="Screen Shot 2022-09-26 at 8 38 50 PM" src="https://user-images.githubusercontent.com/81119399/192654632-c4a01494-2130-40e9-b305-08608616504a.png">

Updated spec requests tests and factory for Data Definitions.

spec controller tests:
<img width="1280" alt="Screen Shot 2022-09-27 at 4 11 56 PM" src="https://user-images.githubusercontent.com/81119399/192654784-b2278640-45c6-438f-b332-60047519758c.png">

spec requests tests:
<img width="1280" alt="Screen Shot 2022-09-27 at 4 14 14 PM" src="https://user-images.githubusercontent.com/81119399/192654864-f9b85f0c-d7da-40ea-bfdf-3b6a7fd23075.png">




