### PR TITLE
AACT-417: Do not crash on show page if load event doesn't have a verifier

### DIFF
--- a/app/controllers/verifiers_controller.rb
+++ b/app/controllers/verifiers_controller.rb
@@ -3,7 +3,7 @@ class VerifiersController < ApplicationController
     before_action :set_verifier, only: [:show]
     
     def index
-      @verifiers = Core::Verifier.all.order(id: :asc)
+      @verifiers = Core::Verifier.all.order(id: :desc)
     end
   
     def show

--- a/app/views/verifiers/index.html.erb
+++ b/app/views/verifiers/index.html.erb
@@ -1,6 +1,6 @@
 <div class = "container">  
     <h1 class= "text-center">Verifiers</h1>
-  </div>
+</div>
   <ul class="list-group">
     <li class="row mb-0 ">
       <div class="col text-center text-wrap text-break list-group-item list-group-item-dark">ID</div>
@@ -8,8 +8,8 @@
     </li>
     <% @verifiers.each do |verifier| %>
       <li class="row mb-0 ">
-      <div class="col text-center text-wrap text-break list-group-item "><%= link_to verifier.id, verifier_path(verifier)  %></div>
-        <div class="col text-center text-wrap text-break list-group-item "><%= verifier.last_run.strftime('%B %d, %Y %I:%M %p') %></div>
+        <div class="col text-center text-wrap text-break list-group-item "><%= link_to verifier.id, verifier_path(verifier)  %></div>
+        <div class="col text-center text-wrap text-break list-group-item "><%= verifier.last_run&.strftime('%B %d, %Y %I:%M %p') %></div>
       </li>
     <% end %>
   </ul>

--- a/app/views/verifiers/show.html.erb
+++ b/app/views/verifiers/show.html.erb
@@ -30,12 +30,12 @@
     <% @verifiers.differences.each do |diff| %>
       <% next if (diff['source'].nil?) %>
       <li class="row mb-0">
-        <div class="col-2 text-wrap text-break list-group-item"><%= diff['source'] %></div>
-        <div class="col-2 text-wrap text-break list-group-item"><%= diff['destination'] %></div>
-        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['source_instances'] %></div>
-        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['destination_instances'] %></div>
-        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['source_unique_values'] %></div>
-        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['destination_unique_values'] %></div>
+        <div class="col-2 text-center text-break list-group-item"><%= diff['source'] %></div>
+        <div class="col-2 text-center text-break list-group-item"><%= diff['destination'] %></div>
+        <div class="col-2 text-center text-break list-group-item"><%= diff['source_instances'] %></div>
+        <div class="col-2 text-center text-break list-group-item"><%= diff['destination_instances'] %></div>
+        <div class="col-2 text-center text-break list-group-item"><%= diff['source_unique_values'] %></div>
+        <div class="col-2 text-center text-break list-group-item"><%= diff['destination_unique_values'] %></div>
       </li>
     <% end %>
   </ul>

--- a/app/views/verifiers/show.html.erb
+++ b/app/views/verifiers/show.html.erb
@@ -1,51 +1,43 @@
 <div class="modal-body">
   <h1>Verifiers</h1>
   <hr/>
-
-
-
   <div class="container-fluid">
-    <h5> <strong>Last Run:</strong> <%= @verifiers.last_run.strftime('%B %d, %Y %I:%M %p') %> </h5>
+    <h5> <strong>Last Run:</strong> <%= @verifiers.last_run&.strftime('%B %d, %Y %I:%M %p') %> </h5>
   </div>
-
   <div class="container-fluid">
     <h5> <strong>Created at:</strong> <%= @verifiers.created_at.strftime('%B %d, %Y %I:%M %p') %> </h5>
   </div>
-
   <div class="container-fluid">
     <h5> <strong>Updated at:</strong> <%= @verifiers.updated_at.strftime('%B %d, %Y %I:%M %p') %> </h5>
   </div>
-
-
- <div class="container-fluid">
-    <h5><strong>Differences:</strong> </h5>
- </div>
- <ul class="list-group ">
- <li class="row mb-0">
-   <div class="col-4 text-wrap text-break list-group-item list-group-item-dark"></div>
-   <div class="col-4 text-center text-wrap text-break list-group-item list-group-item-dark">Instances</div>
-   <div class="col-4 text-center text-wrap text-break list-group-item list-group-item-dark">Unique</div>
- </li>
- <li class="row mb-0">
-   <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
-   <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
-   <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
-   <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
-   <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
-   <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
- </li>
- <% @verifiers.differences.each do |diff| %>
-   <% next if (diff['source'].nil?) %>
-   <li class="row mb-0">
-     <div class="col-2 text-wrap text-break list-group-item"><%= diff['source'] %></div>
-     <div class="col-2 text-wrap text-break list-group-item"><%= diff['destination'] %></div>
-     <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['source_instances'] %></div>
-     <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['destination_instances'] %></div>
-     <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['source_unique_values'] %></div>
-     <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['destination_unique_values'] %></div>
-   </li>
- <% end %>
-</ul>
-
+  <div class="container-fluid">
+    <h5> <strong>Differences:</strong> </h5>
+  </div>
+  <ul class="list-group ">
+    <li class="row mb-0">
+      <div class="col-4 text-wrap text-break list-group-item list-group-item-dark"></div>
+      <div class="col-4 text-center text-wrap text-break list-group-item list-group-item-dark">Instances</div>
+      <div class="col-4 text-center text-wrap text-break list-group-item list-group-item-dark">Unique</div>
+    </li>
+    <li class="row mb-0">
+      <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
+      <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
+      <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
+      <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
+      <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Source</div>
+      <div class="col-2 text-center text-wrap text-break list-group-item list-group-item-dark">Destination</div>
+    </li>
+    <% @verifiers.differences.each do |diff| %>
+      <% next if (diff['source'].nil?) %>
+      <li class="row mb-0">
+        <div class="col-2 text-wrap text-break list-group-item"><%= diff['source'] %></div>
+        <div class="col-2 text-wrap text-break list-group-item"><%= diff['destination'] %></div>
+        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['source_instances'] %></div>
+        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['destination_instances'] %></div>
+        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['source_unique_values'] %></div>
+        <div class="col-2 text-center text-wrap text-break list-group-item"><%= diff['destination_unique_values'] %></div>
+      </li>
+    <% end %>
+  </ul>
   <%= link_to 'Back', verifiers_path, :class => "btn btn-primary btn-sm" %>
 </div>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -16,8 +16,8 @@ FactoryBot.define do
   end
 
   factory :verifier, class: Core::Verifier do
-    differences {{source: "source", destination: "destination", source_instances: "source_instances", destination_instances: "destination_instances", source_unique_values: "source_unique_values", destination_unique_values: "destination_unique_values"}}
-    source {{source: "source"}}
+    differences { [{source: "source", destination: "destination", source_instances: "source_instances", destination_instances: "destination_instances", source_unique_values: "source_unique_values", destination_unique_values: "destination_unique_values"}] }
+    source { {source: "source"} }
     last_run { DateTime.now }
     created_at { DateTime.now }
     updated_at  { DateTime.now }

--- a/spec/requests/verifiers_spec.rb
+++ b/spec/requests/verifiers_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe "Verifiers", type: :request do
+
+    describe "GET /verifiers" do
+      it "renders the Verifiers index page" do
+        get verifiers_path
+        expect(response).to render_template(:index)
+      end
+    end
+
+    describe "GET /verifiers" do
+      it "renders the Verifier show page" do
+        verify = FactoryBot.create(:verifier)
+        get verifier_path(id: verify.id)
+        expect(response).to render_template(:show)
+      end
+      it "redirects to the Verifiers index page if Verifier ID is invalid" do
+        get verifier_path(id: 5000) # an ID that doesn't exist
+        expect(response).to redirect_to verifiers_path
+      end
+    end
+
+end    


### PR DESCRIPTION
- Fixed bug so that the Verifier show and index page does not crash if a load event does not have a verifier. 
- Created Verifiers requests tests Spec file. 
- Updated factories Spec file to be able to run requests tests.

<img width="1280" alt="Screen Shot 2022-10-05 at 10 43 24 AM" src="https://user-images.githubusercontent.com/81119399/194606293-bb845b4c-e1b7-42a9-bf21-11d41dbcfe49.png">
<img width="1280" alt="Screen Shot 2022-10-05 at 10 43 46 AM" src="https://user-images.githubusercontent.com/81119399/194606413-ed6817f4-bea5-46c6-b6ea-8e2d3129c194.png">


Verifiers Controller Spec test:

<img width="1280" alt="Screen Shot 2022-10-05 at 10 40 16 AM" src="https://user-images.githubusercontent.com/81119399/194606533-c124f446-9df4-4bf0-b2b4-ced7ae68ad32.png">

Verifiers Requests Spec test:

<img width="1280" alt="Screen Shot 2022-10-05 at 10 42 07 AM" src="https://user-images.githubusercontent.com/81119399/194606813-305b11e6-4bc0-4e9c-be71-289fea47f5d4.png">

