### PR TITLE
AACT-482: Remove the SQL column from the saved_queries index page

### DIFF
--- a/app/views/saved_queries/index.html.erb
+++ b/app/views/saved_queries/index.html.erb
@@ -15,7 +15,6 @@
         <tr>
           <th>Title</th>
           <th>Description</th>
-          <th>SQL</th>
           <th>User</th>
           <th>Created</th>
         </tr>
@@ -25,7 +24,6 @@
           <tr>
             <td><%= link_to query.title, saved_query_path(query) %> </td>
             <td><%= query.description %></td>
-            <td><%= query.sql %></td>
             <td><%= query.user&.username %></td>
             <td><%= query.created_at.strftime('%B %d, %Y') %></td>
           </tr>


### PR DESCRIPTION
Removed the SQL column from the Saved Queries index page:

<img width="1254" alt="Screen Shot 2023-02-16 at 3 46 29 PM" src="https://user-images.githubusercontent.com/81119399/219505752-ef1dd6d5-d277-401c-94e1-ebf966b4e554.png">
