### PR TITLE
AACT-483: Add Codemirror to the SQL textarea to add syntax highlighting

### DIFF
--- a/app/assets/stylesheets/old/base/_forms.scss
+++ b/app/assets/stylesheets/old/base/_forms.scss
@@ -47,11 +47,6 @@ form {
     width: 20%;   
   }
 
-  span {
-    padding-left: 10px;
-    margin-bottom: 20px;
-    display: block;
-  }
   input, textarea, select {
     display: block;
     padding: .8rem;

--- a/app/assets/stylesheets/old/includes/_forms.scss
+++ b/app/assets/stylesheets/old/includes/_forms.scss
@@ -50,11 +50,6 @@ form {
     padding-left: 0;
   }
 
-  span {
-    padding-left: 10px;
-    margin-bottom: 20px;
-    display: block;
-  }
   input, textarea, select {
     display: block;
     padding: .8rem;

--- a/app/views/query/index.html.erb
+++ b/app/views/query/index.html.erb
@@ -1,3 +1,11 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/codemirror.min.css" integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/codemirror.min.js" integrity="sha512-rdFIN28+neM8H8zNsjRClhJb1fIYby2YCNmoqwnqBDEvZgpcp7MJiX8Wd+Oi6KcJOMOuvGztjrsI59rly9BsVQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/edit/matchbrackets.min.js" integrity="sha512-GSYCbN/le5gNmfAWVEjg1tKnOH7ilK6xCLgA7c48IReoIR2g2vldxTM6kZlN6o3VtWIe6fHu/qhwxIt11J8EBA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/mode/sql/sql.min.js" integrity="sha512-fb0A/RjJvLbWBSNDDNRUER4LHrkVQjlEs3a2myQH047y9+I6wZAZOboHn+EA7ZcEcVwSiH3okO/+XzMlGPqcow==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/show-hint.min.css" integrity="sha512-W/cvA9Wiaq79wGy/VOkgMpOILyqxqIMU+rkneDUW2uqiUT53I6DKmrF4lmCbRG+/YrW0J69ecvanKCCyb+sIWA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/show-hint.min.js" integrity="sha512-4+hfJ/4qrBFEm8Wdz+mXpoTr/weIrB6XjJZAcc4pE2Yg5B06aKS/YLMN5iIAMXFTe0f1eneuLE5sRmnSHQqFNg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/sql-hint.min.js" integrity="sha512-Pue0eeX9BJ4IA+BRNDOFwhQmxPjXIHiHOsvHNc9dQ+3J43swbPQDT9gwC8lzE1TTjR8iIxOd+lNiv4oTBRWqYw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/theme/monokai.min.css" integrity="sha512-R6PH4vSzF2Yxjdvb2p2FA06yWul+U0PDDav4b/od/oXf9Iw37zl10plvwOXelrjV2Ai7Eo3vyHeyFUjhXdBCVQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 
 <%= form_tag("/query", :method => "get") do %>
   <%= label_tag(:query, "Input SQL Query:") %>
@@ -10,7 +18,27 @@
       </ul>
     </div>
   <% end %>
-  <%= text_area_tag(:query, params[:query], :required => "required") %>
+
+
+  <script>
+    CodeMirror(document.getElementById('sql_code'), {
+      mode: 'sql',
+      indentWithTabs: true,
+      smartIndent: true,
+      lineNumbers: true,
+      matchBrackets : true,
+      autofocus: true,
+      theme: 'monokai',
+      extraKeys: {"Ctrl-Space": "autocomplete"}
+    });      
+  </script>
+
+ 
+  <div id="sql_code"> 
+    <%= text_area_tag(:query, params[:query], :required => "required") %>
+  </div>
+
+
   <div class="pb-3">
   </div>
   <div class="col-auto">

--- a/app/views/query/index.html.erb
+++ b/app/views/query/index.html.erb
@@ -18,27 +18,24 @@
       </ul>
     </div>
   <% end %>
-
   <%= text_area_tag(:query, params[:query]) %>
-  <script>
-    CodeMirror.fromTextArea(document.getElementById('query'), {
-      mode: 'sql',
-      indentWithTabs: true,
-      smartIndent: true,
-      lineNumbers: true,
-      matchBrackets : true,
-      autofocus: true,
-      theme: 'monokai',
-      extraKeys: {"Ctrl-Space": "autocomplete"}
-    });      
-  </script>
-  
   <div class="pb-3"></div>
   <div class="col-auto">
     <button type="submit" class="btn btn-primary btn-sm">Execute SQL Query</button>
   </div>
 <% end %>
-
+<script>
+  CodeMirror.fromTextArea(document.getElementById('query'), {
+    mode: 'sql',
+    indentWithTabs: true,
+    smartIndent: true,
+    lineNumbers: true,
+    matchBrackets : true,
+    autofocus: true,
+    theme: 'monokai',
+    extraKeys: {"Ctrl-Space": "autocomplete"}
+  });      
+</script>
 <div class="pb-5"></div>
 <% if @results %>
   <% if @results.first %>
@@ -76,4 +73,3 @@
     No results found
   <% end %>
 <% end %>
-

--- a/app/views/query/index.html.erb
+++ b/app/views/query/index.html.erb
@@ -19,9 +19,9 @@
     </div>
   <% end %>
 
-
+  <%= text_area_tag(:query, params[:query]) %>
   <script>
-    CodeMirror(document.getElementById('sql_code'), {
+    CodeMirror.fromTextArea(document.getElementById('query'), {
       mode: 'sql',
       indentWithTabs: true,
       smartIndent: true,
@@ -32,21 +32,14 @@
       extraKeys: {"Ctrl-Space": "autocomplete"}
     });      
   </script>
-
- 
-  <div id="sql_code"> 
-    <%= text_area_tag(:query, params[:query], :required => "required") %>
-  </div>
-
-
-  <div class="pb-3">
-  </div>
+  
+  <div class="pb-3"></div>
   <div class="col-auto">
     <button type="submit" class="btn btn-primary btn-sm">Execute SQL Query</button>
   </div>
 <% end %>
-<div class="pb-5">
-</div>
+
+<div class="pb-5"></div>
 <% if @results %>
   <% if @results.first %>
     <div class="container">

--- a/app/views/saved_queries/_form.html.erb
+++ b/app/views/saved_queries/_form.html.erb
@@ -1,3 +1,12 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/codemirror.min.css" integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/codemirror.min.js" integrity="sha512-rdFIN28+neM8H8zNsjRClhJb1fIYby2YCNmoqwnqBDEvZgpcp7MJiX8Wd+Oi6KcJOMOuvGztjrsI59rly9BsVQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/edit/matchbrackets.min.js" integrity="sha512-GSYCbN/le5gNmfAWVEjg1tKnOH7ilK6xCLgA7c48IReoIR2g2vldxTM6kZlN6o3VtWIe6fHu/qhwxIt11J8EBA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/mode/sql/sql.min.js" integrity="sha512-fb0A/RjJvLbWBSNDDNRUER4LHrkVQjlEs3a2myQH047y9+I6wZAZOboHn+EA7ZcEcVwSiH3okO/+XzMlGPqcow==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/show-hint.min.css" integrity="sha512-W/cvA9Wiaq79wGy/VOkgMpOILyqxqIMU+rkneDUW2uqiUT53I6DKmrF4lmCbRG+/YrW0J69ecvanKCCyb+sIWA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/show-hint.min.js" integrity="sha512-4+hfJ/4qrBFEm8Wdz+mXpoTr/weIrB6XjJZAcc4pE2Yg5B06aKS/YLMN5iIAMXFTe0f1eneuLE5sRmnSHQqFNg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/sql-hint.min.js" integrity="sha512-Pue0eeX9BJ4IA+BRNDOFwhQmxPjXIHiHOsvHNc9dQ+3J43swbPQDT9gwC8lzE1TTjR8iIxOd+lNiv4oTBRWqYw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/theme/monokai.min.css" integrity="sha512-R6PH4vSzF2Yxjdvb2p2FA06yWul+U0PDDav4b/od/oXf9Iw37zl10plvwOXelrjV2Ai7Eo3vyHeyFUjhXdBCVQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
 <%= form_for(saved_query) do |f| %>
   <% if saved_query.errors.any? %>
     <div id="error_explanation">
@@ -20,7 +29,7 @@
     </div>
     <div class="container-fluid">
       <%= f.label :sql %>
-      <%= f.text_area :sql, rows: 5, class: "form-control" %>
+      <%= f.text_area :sql, id: "query" %>
     </div>
     <div class="pb-3"></div>
     <div class="container-fluid">
@@ -36,3 +45,16 @@
     </div>
   </div>
 <% end %>
+
+<script>
+  CodeMirror.fromTextArea(document.getElementById('query'), {
+    mode: 'sql',
+    indentWithTabs: true,
+    smartIndent: true,
+    lineNumbers: true,
+    matchBrackets : true,
+    autofocus: true,
+    theme: 'monokai',
+    extraKeys: {"Ctrl-Space": "autocomplete"}
+  });      
+</script>

--- a/app/views/saved_queries/show.html.erb
+++ b/app/views/saved_queries/show.html.erb
@@ -19,7 +19,6 @@
   <div class="container-fluid">
     <h5><%= @saved_query.public ? 'Public' : 'Not Public' %></h5>
   </div>
-
   <div class="pb-3"></div>
   <%= form_tag("/query", :method => "get") do %>
     <%= label_tag(:query, 'SQL Query:') %>
@@ -32,27 +31,12 @@
         </ul>
       </div>
     <% end %>
-
     <%= text_area_tag(:query, @saved_query.sql) %>
-    <script>
-      CodeMirror.fromTextArea(document.getElementById('query'), {
-        mode: 'sql',
-        indentWithTabs: true,
-        smartIndent: true,
-        lineNumbers: true,
-        matchBrackets : true,
-        autofocus: true,
-        theme: 'monokai',
-        extraKeys: {"Ctrl-Space": "autocomplete"}
-      });      
-    </script>
-
     <div class="pb-3"></div>
     <div class="d-flex">
       <div class="me-auto">
         <button type="submit" class="btn btn-primary btn-sm">Execute SQL Query</button>
       </div>
-      
       <% if @saved_query.user_id == current_user.id %>
         <div class="d-flex gap-3">
           <div>
@@ -65,9 +49,21 @@
       <% end %>
     </div>
   <% end %>
-
   <div class="pb-5"></div>
   <div>
     <%= link_to 'Back', saved_queries_path, :class => "btn btn-primary btn-sm" %>
   </div>
 </div>
+
+<script>
+  CodeMirror.fromTextArea(document.getElementById('query'), {
+    mode: 'sql',
+    indentWithTabs: true,
+    smartIndent: true,
+    lineNumbers: true,
+    matchBrackets : true,
+    autofocus: true,
+    theme: 'monokai',
+    extraKeys: {"Ctrl-Space": "autocomplete"}
+  });      
+</script>

--- a/app/views/saved_queries/show.html.erb
+++ b/app/views/saved_queries/show.html.erb
@@ -1,3 +1,12 @@
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/codemirror.min.css" integrity="sha512-uf06llspW44/LZpHzHT6qBOIVODjWtv4MxCricRxkzvopAlSWnTf6hpZTFxuuZcuNE9CBQhqE0Seu1CoRk84nQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/codemirror.min.js" integrity="sha512-rdFIN28+neM8H8zNsjRClhJb1fIYby2YCNmoqwnqBDEvZgpcp7MJiX8Wd+Oi6KcJOMOuvGztjrsI59rly9BsVQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/edit/matchbrackets.min.js" integrity="sha512-GSYCbN/le5gNmfAWVEjg1tKnOH7ilK6xCLgA7c48IReoIR2g2vldxTM6kZlN6o3VtWIe6fHu/qhwxIt11J8EBA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/mode/sql/sql.min.js" integrity="sha512-fb0A/RjJvLbWBSNDDNRUER4LHrkVQjlEs3a2myQH047y9+I6wZAZOboHn+EA7ZcEcVwSiH3okO/+XzMlGPqcow==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/show-hint.min.css" integrity="sha512-W/cvA9Wiaq79wGy/VOkgMpOILyqxqIMU+rkneDUW2uqiUT53I6DKmrF4lmCbRG+/YrW0J69ecvanKCCyb+sIWA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/show-hint.min.js" integrity="sha512-4+hfJ/4qrBFEm8Wdz+mXpoTr/weIrB6XjJZAcc4pE2Yg5B06aKS/YLMN5iIAMXFTe0f1eneuLE5sRmnSHQqFNg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/addon/hint/sql-hint.min.js" integrity="sha512-Pue0eeX9BJ4IA+BRNDOFwhQmxPjXIHiHOsvHNc9dQ+3J43swbPQDT9gwC8lzE1TTjR8iIxOd+lNiv4oTBRWqYw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.11/theme/monokai.min.css" integrity="sha512-R6PH4vSzF2Yxjdvb2p2FA06yWul+U0PDDav4b/od/oXf9Iw37zl10plvwOXelrjV2Ai7Eo3vyHeyFUjhXdBCVQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+
 <div class="modal-body">
   <h1>Saved Query</h1>
   <hr/>
@@ -10,6 +19,7 @@
   <div class="container-fluid">
     <h5><%= @saved_query.public ? 'Public' : 'Not Public' %></h5>
   </div>
+
   <div class="pb-3"></div>
   <%= form_tag("/query", :method => "get") do %>
     <%= label_tag(:query, 'SQL Query:') %>
@@ -22,12 +32,27 @@
         </ul>
       </div>
     <% end %>
-    <%= text_area_tag(:query, @saved_query.sql, :required => "required", :size =>"25x5") %>
+
+    <%= text_area_tag(:query, @saved_query.sql) %>
+    <script>
+      CodeMirror.fromTextArea(document.getElementById('query'), {
+        mode: 'sql',
+        indentWithTabs: true,
+        smartIndent: true,
+        lineNumbers: true,
+        matchBrackets : true,
+        autofocus: true,
+        theme: 'monokai',
+        extraKeys: {"Ctrl-Space": "autocomplete"}
+      });      
+    </script>
+
     <div class="pb-3"></div>
     <div class="d-flex">
       <div class="me-auto">
         <button type="submit" class="btn btn-primary btn-sm">Execute SQL Query</button>
       </div>
+      
       <% if @saved_query.user_id == current_user.id %>
         <div class="d-flex gap-3">
           <div>
@@ -40,6 +65,7 @@
       <% end %>
     </div>
   <% end %>
+
   <div class="pb-5"></div>
   <div>
     <%= link_to 'Back', saved_queries_path, :class => "btn btn-primary btn-sm" %>


### PR DESCRIPTION
Added CodeMirror to the SQL textarea in the Query index page:

<img width="1276" alt="Screen Shot 2023-03-06 at 8 58 39 AM" src="https://user-images.githubusercontent.com/81119399/223181594-fda45d3b-9b89-422b-8417-037d663836be.png">

Added CodeMirror to the SQL textarea in the Saved Queries show page:

<img width="1276" alt="Screen Shot 2023-03-06 at 9 00 26 AM" src="https://user-images.githubusercontent.com/81119399/223181879-5c1eefd3-7c0d-4a74-bbcf-b6f9f0352ac6.png">

Added CodeMirror to the SQL textarea in the Saved Queries new page:

<img width="1276" alt="Screen Shot 2023-03-06 at 9 02 44 AM" src="https://user-images.githubusercontent.com/81119399/223182077-fcf03bdc-e11d-47b2-a862-1673a572d92e.png">

Added CodeMirror to the SQL textarea in the Saved Queries edit page:

<img width="1276" alt="Screen Shot 2023-03-06 at 9 04 09 AM" src="https://user-images.githubusercontent.com/81119399/223182251-ed3f6b7e-9701-4079-88ae-75dda4e965e5.png">
