### PR TITLE
AACT-475: Query submission

### DIFF
--- a/app/controllers/query_controller.rb
+++ b/app/controllers/query_controller.rb
@@ -1,31 +1,17 @@
 class QueryController < ApplicationController
-  require 'csv'
 
   def index
     if params[:query]
       begin
-        @results = Query::Base.connection.execute(params[:query])
-      # if there is an error in the SQL query, display the form again with the error message
-      rescue ActiveRecord::StatementInvalid => e
-        @error = [e.message]
-      end
-    end
-
-    respond_to do |format|
-      format.csv  do
-        response.headers['Content-Type'] = 'text/csv'
-        response.headers['Content-Disposition'] = 'attachment; filename=query.csv'
-        # get headers from the keys of query results to generate first line of csv file
-        headers = @results.first.map { |key,value| key }
-        csv = CSV.generate_line headers
-        # get rows from the values of the keys of query results to generate rest of lines of csv file
-        @results.each do |result|
-          rows = result.each.map { |key,value| value }  
-          csv << CSV.generate_line(rows).html_safe
+        # instead of running the query, create a background job if user has less than 10 jobs in the queue    
+        if current_user.background_jobs.where(status: ['pending', 'running']).count < 10
+          @background_job = BackgroundJob.create(user_id: current_user.id, status: 'pending', type: 'BackgroundJob', data: params[:query])
+          redirect_to background_job_path(@background_job.id), notice: "The query was added to the queue successfully."
+        else 
+          redirect_to background_jobs_path, alert: "Cannot run query. You can only have a maximum of 10 queries in the queue."
         end
-        render plain: csv
-      end
-      format.html { render template: 'query/index.html.erb' }
-    end
+      end    
+    end  
   end
+
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 12.13 (Ubuntu 12.13-0ubuntu0.20.04.1)
--- Dumped by pg_dump version 12.13 (Ubuntu 12.13-0ubuntu0.20.04.1)
+-- Dumped from database version 14.6 (Homebrew)
+-- Dumped by pg_dump version 14.6 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -570,6 +570,42 @@ CREATE TABLE ctgov.schema_migrations (
 
 
 --
+-- Name: table_saved_queries; Type: TABLE; Schema: ctgov; Owner: -
+--
+
+CREATE TABLE ctgov.table_saved_queries (
+    id integer NOT NULL,
+    title character varying,
+    description character varying,
+    sql character varying,
+    public boolean,
+    user_id integer NOT NULL,
+    created_at timestamp without time zone,
+    updated_at timestamp without time zone
+);
+
+
+--
+-- Name: table_saved_queries_id_seq; Type: SEQUENCE; Schema: ctgov; Owner: -
+--
+
+CREATE SEQUENCE ctgov.table_saved_queries_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: table_saved_queries_id_seq; Type: SEQUENCE OWNED BY; Schema: ctgov; Owner: -
+--
+
+ALTER SEQUENCE ctgov.table_saved_queries_id_seq OWNED BY ctgov.table_saved_queries.id;
+
+
+--
 -- Name: use_case_attachments; Type: TABLE; Schema: ctgov; Owner: -
 --
 
@@ -899,6 +935,13 @@ ALTER TABLE ONLY ctgov.saved_queries ALTER COLUMN id SET DEFAULT nextval('ctgov.
 
 
 --
+-- Name: table_saved_queries id; Type: DEFAULT; Schema: ctgov; Owner: -
+--
+
+ALTER TABLE ONLY ctgov.table_saved_queries ALTER COLUMN id SET DEFAULT nextval('ctgov.table_saved_queries_id_seq'::regclass);
+
+
+--
 -- Name: use_case_attachments id; Type: DEFAULT; Schema: ctgov; Owner: -
 --
 
@@ -1050,6 +1093,14 @@ ALTER TABLE ONLY ctgov.releases
 
 ALTER TABLE ONLY ctgov.saved_queries
     ADD CONSTRAINT saved_queries_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: table_saved_queries table_saved_queries_pkey; Type: CONSTRAINT; Schema: ctgov; Owner: -
+--
+
+ALTER TABLE ONLY ctgov.table_saved_queries
+    ADD CONSTRAINT table_saved_queries_pkey PRIMARY KEY (id);
 
 
 --
@@ -1247,6 +1298,8 @@ INSERT INTO schema_migrations (version) VALUES ('20211027220743');
 INSERT INTO schema_migrations (version) VALUES ('20211102194357');
 
 INSERT INTO schema_migrations (version) VALUES ('20211109190158');
+
+INSERT INTO schema_migrations (version) VALUES ('20221005135246');
 
 INSERT INTO schema_migrations (version) VALUES ('20221018210501');
 

--- a/spec/controllers/query_controller_spec.rb
+++ b/spec/controllers/query_controller_spec.rb
@@ -3,38 +3,8 @@ require 'rails_helper'
 RSpec.describe QueryController, type: :controller do
 
   describe "GET #index" do
-    it "returns http success with an invalid SQL Query" do
-      get :index, query: 'SELECT nct_id, study_type, brief_title, enrollment, has_dmc, completion_date, updated_at FROM LIMIT 20'
-      expect(response).to have_http_status(:success)
-    end
-  end
-  
-  describe "GET #index" do
     it "returns http success" do
-      get :index, query: 'SELECT nct_id, study_type, brief_title, enrollment, has_dmc, completion_date, updated_at FROM studies LIMIT 20'
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET #index" do
-    it "format html file, returns http success" do
-      get :index, format: :html, query: 'SELECT nct_id, study_type, brief_title, enrollment, has_dmc, completion_date, updated_at FROM studies LIMIT 5'
-      expect(response).to have_http_status(:success)
-    end
-  end
-
-  describe "GET #index" do
-    #  Can't create a study because Public::Study is READONLY, need to write SQL explicitly
-    before(:each) do
-      Query::Base.connection.execute("INSERT INTO studies(nct_id, brief_title, created_at, updated_at) VALUES('1238','hello', '2018-10-31', '2018-12-25')")
-    end
-    
-    after(:each) do
-      Query::Base.connection.execute("DELETE FROM studies WHERE nct_id = '1238'")
-    end
-    
-    it "format csv file, returns http success" do
-      get :index, format: :csv, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get :index
       expect(response).to have_http_status(:success)
     end
   end

--- a/spec/requests/queries_spec.rb
+++ b/spec/requests/queries_spec.rb
@@ -2,68 +2,57 @@ require 'rails_helper'
 
 RSpec.describe "Queries", type: :request do
 
-  describe "GET /query with invalid SQL query" do
-    #  Can't create a study because Public::Study is READONLY, need to write SQL explicitly
-    before(:each) do
-      Query::Base.connection.execute("INSERT INTO studies(nct_id, brief_title, created_at, updated_at) VALUES('1239','hello', '2018-10-31', '2018-12-25')")
-    end
-    
-    after(:each) do
-      Query::Base.connection.execute("DELETE FROM studies WHERE nct_id = '1239'")
-    end
-
-    it "does not run an SQL query and renders the index page" do
-      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM WHERE nct_id='1239'"
-      expect(response).to render_template('query/index.html.erb')
-    end
+  before do
+    @user = User.create(email: 'UserEmail@email.com', first_name: 'Firstname', last_name: 'Lastname', username: 'user123', password: '1234567', db_activity: nil, last_db_activity: nil, admin: false)
+    @user.confirm
+    sign_in(@user)
+    @user_admin = User.create(email: 'UserAdminEmail@email.com', first_name: 'FirstnameAdmin', last_name: 'LastnameAdmin', username: 'useradmin123', password: '1234567', db_activity: nil, last_db_activity: nil, admin: true)
+    @user_admin.confirm
   end
-  
-  describe "GET /query with valid SQL query" do
-    #  Can't create a study because Public::Study is READONLY, need to write SQL explicitly
-    before(:each) do
-      Query::Base.connection.execute("INSERT INTO studies(nct_id, brief_title, created_at, updated_at) VALUES('1238','hello', '2018-10-31', '2018-12-25')")
-    end
-    
-    after(:each) do
-      Query::Base.connection.execute("DELETE FROM studies WHERE nct_id = '1238'")
-    end
 
-    it "runs an SQL query and renders the index page" do
+  after do
+    # delete all Background Jobs associated with each User before deleting each User
+    @user.background_jobs.each do |job|
+      job.destroy
+    end  
+    @user.destroy
+    @user_admin.background_jobs.each do |job|
+      job.destroy
+    end  
+    @user_admin.destroy
+  end
+
+  describe "GET /query" do
+    it "renders the Query index page" do
+      get query_path
+      expect(response).to render_template(:index)
+    end
+    it "if less than 10 Background Jobs, creates a new Job and redirects to the Job's show page" do
       get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
-      expect(response).to render_template('query/index.html.erb')
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      expect(response).to redirect_to background_job_path(id: BackgroundJob.last.id)
     end
-  end
-
-  describe "GET /query with valid SQL query and respond to format html" do
-    #  Can't create a study because Public::Study is READONLY, need to write SQL explicitly
-    before(:each) do
-      Query::Base.connection.execute("INSERT INTO studies(nct_id, brief_title, created_at, updated_at) VALUES('1238','hello', '2018-10-31', '2018-12-25')")
-    end
-    
-    after(:each) do
-      Query::Base.connection.execute("DELETE FROM studies WHERE nct_id = '1238'")
-    end
-
-    it "runs an SQL query and renders the index html" do
-      get query_path(format: :html, query:  "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'")
-      expect(response).to render_template('query/index.html.erb')
-    end
-  end
-
-  describe "GET /query with valid SQL query and respond to format CSV" do
-    #  Can't create a study because Public::Study is READONLY, need to write SQL explicitly
-    before(:each) do
-      Query::Base.connection.execute("INSERT INTO studies(nct_id, brief_title, created_at, updated_at) VALUES('1238','hello', '2018-10-31', '2018-12-25')")
-    end
-    
-    after(:each) do
-      Query::Base.connection.execute("DELETE FROM studies WHERE nct_id = '1238'")
-    end
-
-    it "runs an SQL query and gets the query path to generate csv file" do
-      get query_path(format: :csv, query: "SELECT nct_id, brief_title, created_at, updated_at has_dmc FROM studies WHERE nct_id='1238'")
-      expect(response.body).to match(/1238/)
-      expect(response.body).to match(/hello/)
+    it "if more than 10 Background Jobs, does NOT create a new Job and redirects to the Background Jobs index page" do
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      get query_path, query: "SELECT nct_id, brief_title, created_at, updated_at FROM studies WHERE nct_id='1238'"
+      expect(response).to redirect_to background_jobs_path
     end
   end
 


### PR DESCRIPTION
Modified the current query submission system so that instead of running the job, we create a background job.

- Added a check that the user cannot have more than 10 jobs in the queue. A job is in the queue if the status is “pending” or “running”.
- Once we create the BackgroundJob, we want to redirect them to the background_job show page for that newly created job.

<img width="1280" alt="Screen Shot 2023-03-27 at 10 05 47 AM" src="https://user-images.githubusercontent.com/81119399/228679442-831cc111-d5fc-4be3-8fb9-f6accf119487.png">

<img width="1280" alt="Screen Shot 2023-03-27 at 10 00 49 AM" src="https://user-images.githubusercontent.com/81119399/228679479-a635099a-79f9-4c6d-953d-b0433c5f039c.png">

- If the user has more than 10 jobs in the queue, do not create a BackgroundJob and redirect to the Background Jobs index page with an alert message.

<img width="1280" alt="Screen Shot 2023-03-27 at 10 23 26 AM" src="https://user-images.githubusercontent.com/81119399/228679613-a236ed15-9bea-45b2-9e06-dee4a4540771.png">

<img width="1280" alt="Screen Shot 2023-03-27 at 10 26 23 AM" src="https://user-images.githubusercontent.com/81119399/228679692-b8cee8a8-8419-4ee1-a7bc-42ca90283037.png">

QueryController RSpec controller test PASS:

<img width="1280" alt="Screen Shot 2023-03-28 at 2 08 55 PM" src="https://user-images.githubusercontent.com/81119399/228680051-515abb47-61b4-4cc8-9ebc-23d7881cf9bd.png">

QueryController RSpec request tests PASS:

<img width="1280" alt="Screen Shot 2023-03-28 at 2 06 56 PM" src="https://user-images.githubusercontent.com/81119399/228680064-e78d39f7-7cd1-462e-9ba0-47525181163c.png">

