### PR TITLE
kostik/name-in-menu-too-long/AACT-578

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ActiveRecord::Base
   validates_confirmation_of :password
   validates :first_name, presence: true
   validates :last_name, presence: true
-  validates_length_of :first_name, :maximum=>100
+  validates_length_of :first_name, :maximum=>17
   validates_length_of :last_name, :maximum=>100
   validates :username, presence: true
   validates_uniqueness_of :username

--- a/app/views/includes/_dropdown.html.erb
+++ b/app/views/includes/_dropdown.html.erb
@@ -24,10 +24,10 @@
     
     <% elsif user_signed_in? %>
    <div class="nav-svg nav-svg-no-margin dropdown"> 
-        <svg height="74" width="175" class="dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-          <polygon points="0,0 150,0 175,37 150,74 0,74 25,37" style="fill:#02b7d4" />
+        <svg height="74" width="298" class="dropdown-toggle" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <polygon points="0,0 255,0 297,37 255,74 0,74 25,37" style="fill:#02b7d4" />
           <text
-          x="50%" y="50%"
+          x="53%" y="50%"
           class="svg-text nav-svg nav-svg-no-margin"
           >Hi, <%= current_user.first_name.capitalize %> <%= current_user.last_name.chr %>.</text>
         </svg>

--- a/spec/features/users_sign_up_page_spec.rb
+++ b/spec/features/users_sign_up_page_spec.rb
@@ -37,7 +37,7 @@ feature "Users Sign Up Page" do
     fill_in 'user_first_name', with: long_name
     fill_in 'user_last_name', with: long_name
     submit
-    expect(page).to have_content "First name is too long (maximum is 100 characters)"
+    expect(page).to have_content "First name is too long (maximum is 17 characters)"
     expect(page).to have_content "Last name is too long (maximum is 100 characters)"
     expect(page).not_to have_content "First name can't be blank"
     expect(page).not_to have_content "Last name can't be blank"
@@ -49,7 +49,7 @@ feature "Users Sign Up Page" do
     submit
     expect(page).not_to have_content "First name can't be blank"
     expect(page).not_to have_content "Last name can't be blank"
-    expect(page).not_to have_content "First name is too long (maximum is 100 characters)"
+    expect(page).not_to have_content "First name is too long (maximum is 17 characters)"
     expect(page).not_to have_content "Last name is too long (maximum is 100 characters)"
     expect(Util::UserDbManager.new.user_account_exists?(valid_username)).to eq(false)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe User do
-  it { should validate_length_of(:first_name).is_at_most(100) }
+  it { should validate_length_of(:first_name).is_at_most(17) }
   it { should validate_length_of(:last_name).is_at_most(100) }
   it { should validate_length_of(:username).is_at_most(64) }
 


### PR DESCRIPTION
This PR makes the User's name segment in the header longer to fit long first names. The user's first name validation changed to 17 symbols long instead of 100. In ticket's description says that the user's name should be 20 symbols maximum, but after testing I decided to do 17 because the name's segment/polygon is too long and 17 should be enough.  

![image_2023-10-10_14-16-08](https://github.com/ctti-clinicaltrials/aact-admin/assets/58646723/0d041d5c-dc69-4198-b402-13a7be270da0)
