### PR TITLE
AACT-156: Change user to non-root in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM ruby:2.6.6
 
-
 RUN apt-get update -qq && apt-get install -y nodejs postgresql-client 
 
 RUN mkdir /app
@@ -10,9 +9,15 @@ COPY Gemfile.lock /app/Gemfile.lock
 RUN gem install bundler:1.17.3
 RUN bundle install --without development test
 
+# Create non-root user and set ownership and permissions as required
+RUN adduser --disabled-password aact && chown -R aact /app
+
 COPY . /app
 
 RUN RAILS_ENV=production bundle exec rake assets:precompile
+
+# Switch to the user
+USER aact
 
 EXPOSE 3000
 


### PR DESCRIPTION
- Running as the root user in docker creates a security vulnerability.

- Updated the Dockerfile so that we specify a different user to run our code inside docker.

<img width="1222" alt="Screen Shot 2023-10-12 at 11 40 17 AM" src="https://github.com/ctti-clinicaltrials/aact-admin/assets/81119399/160b9f71-c0b9-4f41-b2d7-5f642c147bab">

<img width="1219" alt="Screen Shot 2023-10-12 at 11 47 33 AM" src="https://github.com/ctti-clinicaltrials/aact-admin/assets/81119399/68b03adb-373f-4580-9972-4226ad9a8c30">
