### PR TITLE
feat/AACT-601-adminusers-faqcontroller

### DIFF
--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -5,7 +5,7 @@ class FaqController < ApplicationController
 
   def authenticate_user
     unless user_signed_in? && current_user.admin?
-      render file: Rails.root.join('app', 'views', 'errors', 'unauthorized_user.html.erb'), layout: true, status: :forbidden
+      render 'errors/unauthorized_user', status: :forbidden
     end
   end
 end

--- a/app/controllers/faq_controller.rb
+++ b/app/controllers/faq_controller.rb
@@ -4,13 +4,8 @@ class FaqController < ApplicationController
   private
 
   def authenticate_user
-    render plain: "Sorry - This page is only accessible to administrators." if !current_user_is_an_admin?
+    unless user_signed_in? && current_user.admin?
+      render file: Rails.root.join('app', 'views', 'errors', 'unauthorized_user.html.erb'), layout: true, status: :forbidden
+    end
   end
-
-  def current_user_is_an_admin?
-    return false if !current_user
-    col=AACT::Application::AACT_ADMIN_USERNAMES.split(',')
-    col.include? current_user.username
-  end
-
 end

--- a/app/views/errors/unauthorized_user.html.erb
+++ b/app/views/errors/unauthorized_user.html.erb
@@ -1,0 +1,3 @@
+<!-- app/views/errors/unauthorized_user.html.erb -->
+<h1>Looks like this page encountered an error.</h1>
+<p>Sorry - This page is only accessible to administrators.</p>


### PR DESCRIPTION
change the way admin users are identified in the faq controller, added a error view so user not sign in can see and if user accidently comes across the page will see error.


### **User not sign-in error:**
![Screenshot (6)](https://github.com/ctti-clinicaltrials/aact-admin/assets/50157150/1fa9ec92-c148-467d-a578-4a12afec069f)


### **User (non-admin) sign-in error:**
![Screenshot (7)](https://github.com/ctti-clinicaltrials/aact-admin/assets/50157150/0cfddc8c-cd52-4a27-ba66-1d064cc25bd1)