### PR TITLE
fix/AACT-643 getting an error on playground when not logged in

### DIFF
--- a/app/controllers/playground_controller.rb
+++ b/app/controllers/playground_controller.rb
@@ -1,5 +1,5 @@
 class PlaygroundController < ApplicationController
-
+  before_action :authenticate_user!
   def index
     if params[:query]
       # instead of running the query, create a background job if user has less than 10 jobs in the queue    


### PR DESCRIPTION
Require the user to login in order to use playground
![Screenshot (21)](https://github.com/ctti-clinicaltrials/aact-admin/assets/50157150/905f2e8c-c8b4-4502-a912-296f82b1e01b)
