### PR TITLE
AACT-682 Make history links more user friendly

### DIFF
--- a/app/views/background_jobs/admin_history.html.erb
+++ b/app/views/background_jobs/admin_history.html.erb
@@ -1,40 +1,42 @@
 <div class="container">
   <%= render 'layouts/query_menu' %>
 
-  <div class="search-form">
+  <div class="search-form" style="display: flex; justify-content: space-between; align-items: center;">
     <%= form_tag(admin_history_path, method: :get, class: 'form-inline') do %>
       <div class="form-group" style="display: inline-flex; align-items: center;">
         <%= text_field_tag :search, params[:search], class: 'form-control form-control-sm', style: 'width: 250px; margin-right: 10px;' %>
         <%= submit_tag "Search", class: 'btn btn-primary btn-sm', style: 'width: 100px;' %>
       </div>
     <% end %>
+    <div style="margin-left: auto;">
+      <%= link_to "Show My History", "/history" %>
+    </div>
   </div>
-
+  
   <table id="data-table" class="table table-sm table-striped">
     <tbody>
       <% @admin_history.each do |job| %>
-          <tr class="selectable-row" data-url="<%= background_job_path(job) %>">
-            <td>
-              <% if job.data.present? %>
-                <% job.data.first(1).each do |key, value| %>
-                  <strong><%= value %></strong><br>
-                <% end %>
-                <% if job.data.size > 1 %>
-                  <span class="more-data">click to see more...</span>
-                <% end %>
-              <% else %>
-                No data available
+        <tr class="selectable-row" data-url="<%= background_job_path(job) %>">
+          <td>
+            <% if job.data.present? %>
+              <% job.data.first(1).each do |key, value| %>
+                <strong><%= value %></strong><br>
               <% end %>
-            </td>
-
-            <td class="text-right">
-              <%= job.created_at.strftime('%B %d, %Y at %l:%M %p') %>
-              <br>
-              <%= job.status %>
-              <br>
-              <%= job.user&.username %>
-            </td>
-          </tr>
+              <% if job.data.size > 1 %>
+                <span class="more-data">click to see more...</span>
+              <% end %>
+            <% else %>
+              No data available
+            <% end %>
+          </td>
+          <td class="text-right">
+            <%= job.created_at.strftime('%B %d, %Y at %l:%M %p') %>
+            <br>
+            <%= job.status %>
+            <br>
+            <%= job.user&.username %>
+          </td>
+        </tr>
       <% end %>
     </tbody>
   </table>

--- a/app/views/background_jobs/history.html.erb
+++ b/app/views/background_jobs/history.html.erb
@@ -8,6 +8,11 @@
         <%= submit_tag "Search", class: 'btn btn-primary btn-sm', style: 'width: 100px;' %>
       </div>
     <% end %>
+    <% if current_user.admin? %>
+      <div style="margin-left: auto;">
+        <%= link_to "Show Everyone", "/admin/history" %>
+      </div>
+    <% end %>
   </div>
 
   <table id="data-table" class="table table-sm table-striped">

--- a/app/views/layouts/_query_menu.html.erb
+++ b/app/views/layouts/_query_menu.html.erb
@@ -1,36 +1,18 @@
-<% if current_user.admin? %>
 <div class="container">
   <div class="pb-5">
-  <div class="pb-4"></div>
-  <ul class="query-menu">
-    <li class="query-menu-item"><a href="/playground">Playground</a></li>
-    <li class="query-menu-item"><a href="/history">History</a></li>
-    <li class="query-menu-item"><a href="/my/queries">My Queries</a></li>
-    <li class="query-menu-item"><a href="/queries">Community Queries</a></li>
-    <li class="query-menu-item"><a href="/admin/history">Admin History</a></li>
-  </ul>
-  
-  <ul class="query-menu-right">
-    <li class="query-menu-right-item"><a href="/contactus">Feedback</a></li>
-    <li class="query-menu-right-item"><a href="/saved_query_doc">Help</a></li>
-  </ul>
+    <div class="pb-4"></div>
+    <ul class="query-menu">
+      <li class="query-menu-item"><a href="/playground">Playground</a></li>
+      <li class="query-menu-item"><a href="/history">History</a></li>
+      <li class="query-menu-item"><a href="/my/queries">My Queries</a></li>
+      <li class="query-menu-item"><a href="/queries">Community Queries</a></li>
+    </ul>
+    
+    <ul class="query-menu-right">
+      <li class="query-menu-right-item"><a href="/contactus">Feedback</a></li>
+      <li class="query-menu-right-item"><a href="/saved_query_doc">Help</a></li>
+    </ul>
+  </div>
 </div>
-<% else %>
-<div class="container">
-  <div class="pb-5">
-  <div class="pb-4"></div>
-  <ul class="query-menu">
-    <li class="query-menu-item"><a href="/playground">Playground</a></li>
-    <li class="query-menu-item"><a href="/history">History</a></li>
-    <li class="query-menu-item"><a href="/my/queries">My Queries</a></li>
-    <li class="query-menu-item"><a href="/queries">Community Queries</a></li>
-  </ul>
-  
-  <ul class="query-menu-right">
-    <li class="query-menu-right-item"><a href="/contactus">Feedback</a></li>
-    <li class="query-menu-right-item"><a href="/saved_query_doc">Help</a></li>
-  </ul>
-</div>
-<% end %>
 
 <%= javascript_include_tag 'query_menu', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
- Remove the link “Admin History” from the top navigation
- On the top right corner on the other side of the search add a link to the admin history, that says “Show Everyone”
- On the admin history page, on the other side of the search add a link that says “Show My History”

### **Screenshots:**
Admin History
![admin_history](https://github.com/ctti-clinicaltrials/aact-admin/assets/50157150/76f758f6-ecdd-4674-be65-ec0d49411551)
Admin History Everyone
![admin_history_everyone](https://github.com/ctti-clinicaltrials/aact-admin/assets/50157150/ed82d647-4dd2-4c5c-93ee-1c32e0f63883)
User History - non admin
![user_history](https://github.com/ctti-clinicaltrials/aact-admin/assets/50157150/be8d1358-4d93-43f4-a97b-44a2fc75e073)


