### PR TITLE
AACT-718 Updated total study count to use new v2 API

### DIFF
--- a/app/models/clinical_trials_api_v2.rb
+++ b/app/models/clinical_trials_api_v2.rb
@@ -31,6 +31,10 @@ class ClinicalTrialsApiV2
     JSON.parse(body)
   end
 
+  def self.number_of_studies
+    ClinicalTrialsApiV2.size.dig('totalStudies')
+  end
+
   #Values stats
   def self.values
     body = Faraday.get("#{BASE_URL_V2}/stats/fieldValues").body

--- a/app/views/summary/aact.html.erb
+++ b/app/views/summary/aact.html.erb
@@ -9,7 +9,7 @@
   </div>
 
   <div>
-    <p><b>ClinicalTrials.gov:</b> <%= ClinicalTrialsApi::number_of_studies %> &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;     
+    <p><b>ClinicalTrials.gov:</b> <%= ClinicalTrialsApiV2::number_of_studies %> &emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;     
        <b>AACT:</b> <%= Public::Study.count %>
     </p>
   </div>

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -3,7 +3,7 @@ require 'webmock/rspec'
 
 RSpec.describe SummaryController, type: :controller do
   before do
-    stub_request(:get, "https://classic.clinicaltrials.gov/api//info/study_statistics?fmt=json").
+    stub_request(:get, "https://clinicaltrials.gov/api/v2//stats/size?fmt=json").
          with(
            headers: {
           'Accept'=>'*/*',

--- a/spec/controllers/summary_controller_spec.rb
+++ b/spec/controllers/summary_controller_spec.rb
@@ -2,15 +2,17 @@ require 'rails_helper'
 require 'webmock/rspec'
 
 RSpec.describe SummaryController, type: :controller do
+  # binding.pry
   before do
-    stub_request(:get, "https://clinicaltrials.gov/api/v2//stats/size?fmt=json").
-         with(
-           headers: {
+    stub_request(:get, "https://clinicaltrials.gov/api/v2//stats/size").
+      with(
+        headers: {
           'Accept'=>'*/*',
           'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'User-Agent'=>'Faraday v1.10.3'
-           }).
-         to_return(status: 200, body: "{}", headers: {})
+        }).
+    to_return(status: 200, body: "{}", headers: {})
+
     @user = create(:user, admin: true)
     @user.confirm
     sign_in(@user)


### PR DESCRIPTION
[AACT-718](https://codethedream.atlassian.net/browse/AACT-718)


## Description:
 Updated summary page to use new `https://clinicaltrials.gov/api/v2/stats/size` API to get the total study size:

### Before:

![image](https://github.com/ctti-clinicaltrials/aact-admin/assets/66342665/3d296d63-9941-4233-991a-5e066b587c48)

### After:
![image](https://github.com/ctti-clinicaltrials/aact-admin/assets/66342665/f5ec42cb-2907-43f6-bd00-02e30d7cdb8a)
