### PR TITLE
Fix Data Definition CSV file Rendering

### DIFF
--- a/app/views/definitions/index.csv.erb
+++ b/app/views/definitions/index.csv.erb
@@ -1,5 +1,5 @@
 <%- headers = ['CTTI note', 'column', 'data type', 'db schema', 'db section', 'nlm doc', 'row count', 'source', 'table', 'enumerations'] -%>
 <%= CSV.generate_line(headers) -%>
 <%- @data_def_entries.each do |data_def_entry| -%>
-<%= CSV.generate_line([data_def_entry['CTTI note'], data_def_entry['column'], data_def_entry['data type'], data_def_entry['db schema'], data_def_entry['db section'], data_def_entry['nlm doc'], data_def_entry['row count'], data_def_entry['source'], data_def_entry['table'], data_def_entry['enumerations']]) -%>
+<%= CSV.generate_line([data_def_entry['CTTI note'], data_def_entry['column'], data_def_entry['data type'], data_def_entry['db schema'], data_def_entry['db section'], data_def_entry['nlm doc'], data_def_entry['row count'], data_def_entry['source'], data_def_entry['table'], data_def_entry['enumerations']]).html_safe -%>
 <%- end -%>


### PR DESCRIPTION
After adding .html_safe Rails stopped escaping special HTML characters and added them as-is which resulted in ignoring internal commas inside text fields when CSV file renders columns based on default comma delimiter

**BEFORE**
<img width="1346" alt="image" src="https://github.com/user-attachments/assets/33bcaabc-9bcf-47e3-a014-04a830319945">

**AFTER**
<img width="1236" alt="image" src="https://github.com/user-attachments/assets/37c376fe-3ea9-46d2-a74d-3310012650c3">

Resolves #342 
