### PR TITLE
Refactored contact us page

### DIFF
--- a/app/views/pages/contactus.html.erb
+++ b/app/views/pages/contactus.html.erb
@@ -1,12 +1,8 @@
 <div>
   <h1>Contact Us</h1>
   <h4>Form to submit Issues/Requests</h4>
-  <iframe class="airtable-embed" src="https://airtable.com/embed/shrsjLUxT5X7Sabi4?backgroundColor=orange" frameborder="0" onmousewheel="" width="100%" height="300" style="background: transparent; border: 1px solid #ccc;"></iframe>
+  <iframe class="airtable-embed" src="https://airtable.com/embed/shrsjLUxT5X7Sabi4?backgroundColor=orange" frameborder="0" onmousewheel="" width="100%" height="1475" style="background: transparent; border: 1px solid #ccc;"></iframe>
   <br>
-  <h4>Status of Issues/Requests</h4>
-  <p>If you discover an issue please see if there is a similar issue that we are working on already. If there isn't please fill out the form below and let us know about it.</p>
-  <p> If you have an inquiry that is not related to AACT please contact CTTI directly <a href="https://ctti-clinicaltrials.org/contact-us/">here</a>.</p>
-  <iframe class="airtable-embed" src="https://airtable.com/embed/shrmhjOdSzZ9WLqd6?backgroundColor=orange&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="300" style="background: transparent; border: 1px solid #ccc;"></iframe>
   
   <div style="display: none;"><%= ENV['PUBLIC_DB_HOST'] %></div>
 


### PR DESCRIPTION
### Description:
 - Refactored contact us page.
 - Removed `Status of Issues/Requests`
 - Adjusted height of the embedded AirTable to be full length of the page.
 
 
 ### Before:
 
![image](https://github.com/user-attachments/assets/201ac4da-dc24-4c91-9374-a7c13b0498cf)

### After:

![image](https://github.com/user-attachments/assets/de677226-a119-4aee-9fb1-d83e0e887cdf)
