### PR TITLE
Links to Documenation Page

### DIFF
--- a/app/views/dictionary/show.html.erb
+++ b/app/views/dictionary/show.html.erb
@@ -1,24 +1,19 @@
 <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jsgrid/1.5.3/jsgrid.min.css" />
 <link type="text/css" rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jsgrid/1.5.3/jsgrid-theme.min.css" />
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jsgrid/1.5.3/jsgrid.min.js"></script>
-
 <section class="dataDictionaryShow">
   <main>
     <h1>AACT Data Dictionary</h1>
-
     <section>
       <p>AACT is composed of <%= @tables.size %> tables that provide information related to clinical trials. The database contains multiple schemas, the main one being 'ctgov' which provides data retrieved from ClinicalTrials.gov. The main table in the ctgov schema is 'studies' which relates to all other ctgov tables through the NCT_ID. The ctgov schema also includes 2 tables that provide MeSH terms <a href='https://www.nlm.nih.gov/mesh/meshhome.html' target=_blank'>(Medical Subject Headings)</a> which are published by the National Library of Medicine (NLM). The NLM has populated <i>browse_conditions</i> and <i>browse_interventions</i> tables with the MeSH terms they've determined help describe a study. The NLM updates the MeSH thesaurus each year. AACT provides some older versions of the MeSH thesaurus in the 'mesh_archive' schema.</p>
       <p>AACT also includes a set of project schemas (prefixed with <i>'proj_'</i>) which contain datasets collected/curated by previous researchers who used the AACT database to conduct their study. These datasets enhance the value of the clinical trials data in a number of ways. Descriptions of project schema tables & columns are included in the data dictionary below. The <a href='/shared_data' target='_blank'>Shared Data page</a> provides more comprehensive information about these datasets.</p>
     </section>
-
-    <h3>AACT Data Elements</h3>
-    <%= render 'data_dictionary_instructions' %>
-      <div id="jsGrid" data-schema="ctgov"></div>
+    <%# <h3>AACT Data Elements</h3> %>
+    <%# render 'data_dictionary_instructions' %>
+    <%# <div id="jsGrid" data-schema="ctgov"></div> %>
     <%= render 'table_dictionary' %>
     <%= render 'view_dictionary' %>
-  <main>
-
-  <%= render 'pages/download_database_specs' %>
-
-  <%= render "javascript" %>
-</section>
+    <main>
+      <%= render 'pages/download_database_specs' %>
+      <%= render "javascript" %>
+    </section>

--- a/app/views/pages/learn_more.html.erb
+++ b/app/views/pages/learn_more.html.erb
@@ -10,6 +10,12 @@
          <p>Review the blueprint that describes how AACT is structured and how ClinicalTrials.gov protocol & result data have been organized into related tables. Also defines the conventions and considerations that went into the db design.</p>
          <%= fa_icon('database') %>
       </a>
+      <!-- New Documentation -->
+      <a href='/documentation' class='learnMoreCard'>
+        <h3>Documentation</h3>
+        <p>Explore the list of all schema fields with additional information, including mapping to Clinical Trial data points and description links. Download CSV files of the documentation data.</p>
+        <%= fa_icon('graduation-cap') %>
+      </a>
       <a href='/data_dictionary' class='learnMoreCard'>
          <h3>Data Dictionary</h3>
          <p>Access detailed information about all AACT data elements and how they relate to ClinicalTrials.gov information and corresponding definitions from the National Library of Medicine’s data definitions.</p>

--- a/app/views/pages/schema.html.erb
+++ b/app/views/pages/schema.html.erb
@@ -22,8 +22,9 @@
       (right click on the resulting page to download)
     </li>
     <li>
-      <a href=<%= '/definitions.csv' %> target="_blank" onClick="ga('send','event','download','download data dictionary')">excel version of data dictionary</a> 
-      (online searchable version also available <a href='/data_dictionary' target='_blank'>here</a>)
+      <a href="/documentation">Review Documenentation</a>
+      <span> or </span>
+      <a href="/documentation/download_csv">Download CSV version</a>
     </li>
     <li><a href=<%= @table_dictionary %> target="_blank" onClick="ga('send','event','download','download data dictionary')">excel version of table definitions</a></li>
   </ul>


### PR DESCRIPTION
- added documentation link to learn page
- commented out legacy online dictionary table
- updated links on schema page

<img width="685" alt="image" src="https://github.com/user-attachments/assets/5a2382d2-b626-466c-bef7-20bedc36cdb3" />


<img width="651" alt="image" src="https://github.com/user-attachments/assets/5bd98abb-0856-40c1-bc59-c6d9c1187e05" />

