### PR TITLE
added redirect to root path after signup

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -12,10 +12,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def create
-    super
-    if resource.errors.size == 0
+    build_resource(sign_up_params)
+
+    if resource.save
+      sign_in(resource)
       UserMailer.send_event_notification('created', resource)
-      flash[:notice] = 'You will soon receive an email from AACT. When you verify your email, you will have acces to your database account.'
+      flash[:notice] = 'Welcome! You have signed up successfully. You will soon receive an email from AACT. When you verify your email, you will have access to your database account.'
+      redirect_to root_path and return
+    else
+      clean_up_passwords(resource)
+      respond_with resource
     end
   end
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,7 +17,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     if resource.save
       sign_in(resource)
       UserMailer.send_event_notification('created', resource)
-      flash[:notice] = 'Welcome! You have signed up successfully. You will soon receive an email from AACT. When you verify your email, you will have access to your database account.'
+      flash[:notice] = 'Welcome! You have signed up successfully. You can now log into your account and access the database.'
       redirect_to root_path and return
     else
       clean_up_passwords(resource)


### PR DESCRIPTION
I removed "super" in the create method in users/registrations_controller.rb because "super" invokes the default behavior in Devise's registrations controller which has an automatic render. Only one redirect/render is allowed or else an error is thrown.

I tried overwriting the automatic render with
 ` def after_sign_up_path_for(resource)
        root_path 
    end`
but this removed the automatic sign in after signing up. To save the automatic sign in functionality and add a redirect to the home page after sign up, I manually wrote the create method.