### PR TITLE
simplified text from first heading until 'How does content...'

### DIFF
--- a/app/assets/stylesheets/documentation.css.scss
+++ b/app/assets/stylesheets/documentation.css.scss
@@ -271,7 +271,7 @@
   box-shadow: none;
 }
 
-.info-box {
+.gray-box {
   border: 1px solid #ccc;
   padding: 1em;
   margin: 1em 0;

--- a/app/assets/stylesheets/documentation.css.scss
+++ b/app/assets/stylesheets/documentation.css.scss
@@ -270,3 +270,10 @@
 #userTable {
   box-shadow: none;
 }
+
+.info-box {
+  border: 1px solid #ccc;
+  padding: 1em;
+  margin: 1em 0;
+  background-color: #f9f9f9;
+}

--- a/app/views/pages/_schema_info.html.erb
+++ b/app/views/pages/_schema_info.html.erb
@@ -2,34 +2,33 @@
   <section class="namingConventions" >
     <h4 id='namingConventions'>Naming Conventions</h4>
     <ul class='regularDisplay'>
-      <li>Table names are plural (e.g., <i>studies, facilities, interventions</i>).</li>
-      <li>Column names are singular (e.g., <i>description, phase, name</i>).</li>
-      <li>Multi-word names use underscores (e.g., <i>mesh_term, study_first_submitted_date</i>).</li>
-      <li>Case is ignored by PostgreSQL; <i>Studies</i>, <i>STUDIES</i>, and <i>studies</i> are equivalent.</li>
-      <li>Study design data from ClinicalTrials.gov use tables prefixed with <i>Design_</i>, distinguishing them from results tables (e.g., <i>Design_Groups</i> vs. <i>Result_Groups</i>).</li>
-      <li>Tables and columns use full names, avoiding abbreviations (e.g., <i>description</i> not <i>desc</i>).</li>
-      <li>Redundant wording is avoided (e.g., <i>Studies.source</i> instead of <i>Studies.study_source</i>).</li>
-      <li id='idInformation'>Columns ending with <i>_id</i> are foreign keys, linking the child table to the parent table's <i>id</i> column. For example:<br>
-        <i>Child_Table.parent_table_id = Parent_Table.id</i><br>
-        A row in <i>Facility_Contacts</i> links to its facility via <i>facility_id</i>:<br>
-        <i>Facility_Contacts.facility_id = Facilities.id</i>
+      <li>Table names are all plural. (ie. <i>studies, facilities, interventions,</i> etc.)</li>
+      <li>Column names are all singular. (ie. <i>description, phase, name</i>, etc.)</li>
+      <li>Table/column names derived from multiple words are delimited with underscores. (ie. <i>mesh_term, study_first_submitted_date, number_of_groups</i>, etc.)</li>
+      <li>Information about study design entered into ClinicalTrials.gov during registration is stored in AACT tables prefixed with <i>design_</i> to distinguish it from the results data. For example, the <i>design_groups</i> table contains registry information about anticipated participant groups, whereas the <i>result_groups</i> table contains information that was entered after the study has completed to describe actual participant groups. <i>design_outcomes</i> contains information about the outcomes to be measured and <i>outcomes</i> contains info about the actual outcomes reported when the study completed.</li>
+      <li>Where possible, tables & columns are given fully qualified names; abbreviations are avoided. (ie. <i>description</i> rather than <i>desc</i>; <i>category</i> rather than <i>ctgry</i>)</li>
+      <li>Unnecessary and duplicate verbiage is avoided. For example: <i>studies.source</i> instead of <i>studies.study_source</i></li>
+      <li id='idInformation'>Columns that end with <i>_id</i> represent foreign keys. The prefix to the <i>_id</i> suffix is always the singular name of the parent table to which the child table is related. These foreign keys always link to the <i>id</i> column of the parent table.</p>
+        <p><i>child_table.parent_table_id = parent_tables.id</i></p>
+        <p>For example, a row in <i>facility_contacts</i> links to it’s facility through the <i>facility_id</i> column.</p>
+        <p><i>facility_contacts.facility_id = facilities.id</i>
       </li>
     </ul>
 
     <h4 id='structure_conventions'>Structural Conventions</h4>
     <ul class='regularDisplay'>
-      <li>All tables include an <i>nct_id</i> column linking rows to the related study in the <i>Studies</i> table. (The schema diagram omits some lines to reduce complexity.)<br>
-        Example: <i>Studies.nct_id = Outcomes.nct_id</i> links outcomes to their study.</li>
-      <li>Every table has a primary key named <i>id</i>, except <i>Studies</i>, which uses <i>nct_id</i> as its primary key.</li>
+      <li>All tables include an <i>nct_id</i> column linking rows to the related study in the <i>studies</i> table.<br>
+        Example: <i>studies.nct_id = outcomes.nct_id</i> links outcomes to their study.</li>
+      <li>Every table has a primary key named <i>id</i>, except <i>studies</i>, which uses <i>nct_id</i> as its primary key.</li>
       <li>Columns ending in <i>_date</i> contain date-type values.</li>
-      <li>Columns with month/year dates are stored as strings with a <i>_month_year</i> suffix; an estimated date (using the 1st day of the month) is in an adjacent <i>_date</i> column. (Applies to <i>Studies</i> table.)</li>
-      <li>Derived or calculated values are stored in the <i>Calculated_Values</i> table.</li>
+      <li>Columns with month/year dates are stored as strings with a <i>_month_year</i> suffix; an estimated date (using the 1st day of the month) is in an adjacent <i>_date</i> column. (Applies to <i>studies</i> table.)</li>
+      <li>Derived or calculated values are stored in the <i>calculated_values</i> table.</li>
     </ul>
 
-    <p>While these conventions are rigorously applied, exceptions exist. For example, the table <i>References</i> would have been preferred over <i>Study_References</i>, but since <i>References</i> is a PostgreSQL reserved word, <i>Study_References</i> is used instead.</p>
+    <p>While these conventions are rigorously applied, exceptions exist. For example, the table <i>references</i> would have been preferred over <i>study_references</i>, but since <i>references</i> is a PostgreSQL reserved word, <i>study_references</i> is used instead.</p>
 
     <h2 id='arms_groups'>How are arms/groups identified?</h2>
-    <div class="info-box"> 
+    <div class="gray-box"> 
       <p>AACT simplifies arm and group data for easier analysis while preserving data integrity.</p>
 
       <p>The National Library of Medicine (NLM) defines:</p>
@@ -41,9 +40,9 @@
       <p>Observational studies use “groups” and interventional studies use “arms,” but AACT standardizes on “group(s)” for clarity.</p>
 
       <h4>Participant Groups: Registry vs. Results</h4>
-      <p>Registry info on participant groups is stored in <i>Design_Groups</i>. Post-study, actual group data are in <i>Result_Groups</i>. These tables are not linked in AACT.</p>
+      <p>Registry info on participant groups is stored in <i>design_groups</i>. Post-study, actual group data are in <i>result_groups</i>. These tables are not linked in AACT.</p>
 
-      <p>Most results in ClinicalTrials.gov are organized by participant group. Except <i>Result_Contacts</i> and <i>Result_Agreements</i>, all results tables relate to groups.</p>
+      <p>Most results in ClinicalTrials.gov are organized by participant group. Except <i>result_contacts</i> and <i>result_agreements</i>, all results tables relate to groups.</p>
 
       <p>AACT categorizes results into:</p>
       <ul class='regularDisplay'>
@@ -53,8 +52,8 @@
         <li>Reported Events</li>
       </ul>
 
-      <p>The <i>Result_Groups</i> table aggregates all groups linked to these results. Related tables (e.g., <i>Outcomes</i>, <i>Baseline_Measures</i>) reference <i>Result_Groups</i> via <i>result_group_id</i>.<br>
-      Example: <i>Outcomes.result_group_id = Result_Groups.id</i>.</p>
+      <p>The <i>result_groups</i> table aggregates all groups linked to these results. Related tables (e.g., <i>outcomes</i>, <i>Baseline_Measures</i>) reference <i>result_groups</i> via <i>result_group_id</i>.<br>
+      Example: <i>outcomes.result_group_id = result_groups.id</i>.</p>
 
       <p>ClinicalTrials.gov assigns each group/result a unique identifier per study, starting with two letters for result type (BG, OG, EG, FG) followed by a three-digit code.</p>
 
@@ -96,7 +95,7 @@
     <h2>Information about dates</h2>
     <p>Initially, ClinicalTrials.gov recorded only month and year (without day) for key dates like start date, completion date, primary completion date, and verification date. Because some dates lack day information, AACT stores these fields as character strings rather than date types, limiting their use in calculations (e.g., study duration or date comparisons).</p>
 
-    <p>To address this, each date element in the <i>Studies</i> table has two columns:</p>
+    <p>To address this, each date element in the <i>studies</i> table has two columns:</p>
     <ol>
       <li>A character-type column showing the original ClinicalTrials.gov value.</li>
       <li>A date-type column suitable for calculations.</li>
@@ -104,7 +103,7 @@
 
     <p>When only month and year are provided, the date-type column defaults to the first day of that month. For example, “June 2014” is stored as “June 2014” in the character column and as “06/01/2014” in the date column.</p>
 
-    <div id='pending_results' class="info-box"> 
+    <div id='pending_results' class="gray-box"> 
       <h2>Information about dates related to pending results</h2>
       <p>On May 9, 2018, NLM added the <i>pending_results</i> section to the ClinicalTrials.gov API. It tracks dates for result submissions undergoing quality control (QC) review before public posting.</p>
 
@@ -128,22 +127,22 @@
 
 
     <div id='trial_sites'>
-      <h2>Information about trial sites (Facilities and Countries)</h2>
-      <p>The <i>Facilities</i> table stores information about organizations where the study is or was conducted, reflecting data from ClinicalTrials.gov at download time.</p>
+      <h2>Information about trial sites (facilities and countries)</h2>
+      <p>The <i>facilities</i> table stores information about organizations where the study is or was conducted, reflecting data from ClinicalTrials.gov at download time.</p>
 
-      <p>Contact details (name, email, phone) for a facility’s primary and optional backup contacts are available only if the facility’s status (<i>Facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’ and if provided by the data submitter. This information is stored in the <i>Facility_Contacts</i> table, a child of <i>Facilities</i>. Contact info is removed when a facility stops recruiting or when the overall study status (<i>Studies.overall_status</i>) indicates recruitment completion.</p>
+      <p>Contact details (name, email, phone) for a facility’s primary and optional backup contacts are available only if the facility’s status (<i>facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’ and if provided by the data submitter. This information is stored in the <i>facility_contacts</i> table, a child of <i>facilities</i>. Contact info is removed when a facility stops recruiting or when the overall study status (<i>studies.overall_status</i>) indicates recruitment completion.</p>
 
-      <p>Similarly, investigator names and roles at facilities (stored in <i>Facility_Investigators</i>, another child table) are available under the same conditions and are removed once recruiting ends.</p>
+      <p>Similarly, investigator names and roles at facilities (stored in <i>facility_investigators</i>, another child table) are available under the same conditions and are removed once recruiting ends.</p>
 
-      <p>The <i>Countries</i> table lists unique countries per study, including those currently and previously associated. The <i>removed</i> column flags countries no longer linked to the study. This occurs when all facilities in a country are deleted from a study, which may happen for various reasons, such as incorrect data or uninitiated sites.</p>
+      <p>The <i>countries</i> table lists unique countries per study, including those currently and previously associated. The <i>removed</i> column flags countries no longer linked to the study. This occurs when all facilities in a country are deleted from a study, which may happen for various reasons, such as incorrect data or uninitiated sites.</p>
 
-      <p>Since removed facilities do not appear in <i>Facilities</i>, analysts can use the <i>Countries</i> table (including those marked as removed) to supplement trial location data, especially for studies that have completed enrollment.</p>
+      <p>Since removed facilities do not appear in <i>facilities</i>, analysts can use the <i>countries</i> table (including those marked as removed) to supplement trial location data, especially for studies that have completed enrollment.</p>
 
-      <p>For identifying countries with participant enrollment, using either <i>Facilities</i> or <i>Countries</i> (where <i>removed</i> is false) provides equivalent results.</p>
+      <p>For identifying countries with participant enrollment, using either <i>facilities</i> or <i>countries</i> (where <i>removed</i> is false) provides equivalent results.</p>
     </div>
 
 
-    <div id='delayed_results'class="info-box"> 
+    <div id='delayed_results'class="gray-box"> 
       <h2>“Delayed Results” data elements in AACT</h2>
       <p>A responsible party may delay the results submission deadline for up to two years if one of these conditions applies:</p>
 
@@ -152,7 +151,7 @@
         <li>The trial’s sponsor has filed or will file within one year an FDA application for approval, licensure, or clearance of the new use studied. Extensions may be granted for good cause.</li>
       </ul>
 
-      <p>Studies with certification or extension requests record the submission date in <i>Studies.disposition_first_submitted_date</i>.</p>
+      <p>Studies with certification or extension requests record the submission date in <i>studies.disposition_first_submitted_date</i>.</p>
     </div>
 
   </section>

--- a/app/views/pages/_schema_info.html.erb
+++ b/app/views/pages/_schema_info.html.erb
@@ -1,205 +1,159 @@
 <main>
-<section class="namingConventions" >
-   <h4 id='namingConventions'>Naming Conventions</h4>
-   <ul class='regularDisplay'>
-     <li>Table names are all plural. (ie. <i>studies, facilities, interventions,</i> etc.)</li>
-     <li>Column names are all singular. (ie. <i>description, phase, name</i>, etc.)</li>
-     <li>Table/column names derived from multiple words are delimited with underscores. (ie. <i>mesh_term, study_first_submitted_date, number_of_groups</i>, etc.)</li>
-     <li>Case (upper vs lower) is not relevant since PostgreSQL ignores case. <i>Studies</i>, <i>STUDIES</i> and <i>studies</i> all represent the same table and can be used interchangeably.</li>
-     <li>Information about study design entered into ClinicalTrials.gov during registration is stored in AACT tables prefixed with <i>Design_</i> to distinguish it from the results data. For example, the <i>Design_Groups</i> table contains registry information about anticipated participant groups, whereas the <i>Result_Groups</i> table contains information that was entered after the study has completed to describe actual participant groups. <i>Design_Outcomes</i> contains information about the outcomes to be measured and <i>Outcomes</i> contains info about the actual outcomes reported when the study completed.</li>
-     <li>Where possible, tables & columns are given fully qualified names; abbreviations are avoided. (ie. <i>description</i> rather than <i>desc</i>; <i>category</i> rather than <i>ctgry</i>)</li>
-     <li>Unnecessary and duplicate verbiage is avoided. For example: <i>Studies.source</i> instead of <i>Studies.study_source</i></li>
-     <li id='idInformation'>Columns that end with <i>_id</i> represent foreign keys. The prefix to the <i>_id</i> suffix is always the singular name of the parent table to which the child table is related. These foreign keys always link to the <i>id</i> column of the parent table.</p>
-       <p><i>Child_Table.parent_table_id = Parent_Tables.id</i></p>
-       <p>For example, a row in <i>Facility_Contacts</i> links to it’s facility through the <i>facility_id</i> column.</p>
-       <p><i>Facility_Contacts.facility_id = Facilities.id</i>
-     </li>
-  </ul>
-   <h4 id='structure_conventions'>Structural Conventions</h4>
-   <ul class='regularDisplay'>
-     <li>Every table has an <i>nct_id</i> column to link rows to its related study in the <i>Studies</i> table. All study-related data can be linked directly to the <i>Studies</i> table via the <i>nct_id.</i> (Note: The schema diagram omits several of the lines that represent relationships to <i>Studies</i>. This was done to avoid appearing complex and confusing. Relationships to the <i>Studies</i> table can be assumed since every table includes the NCT ID.)</li>
-        <p><i>Studies.nct_id = Outcomes.nct_id</i> will link outcomes to their related study.
-     <li>Every table has the primary key: <i>id</i>. (<i>Studies</i> is the one exception since it's primary key is the unique study identifier assigned by ClinicalTrials.gov: <i>nct_id</i>.)</li>
-     <li>Columns that end with <i>_date</i> contain date-type values.</li>
-     <li>Columns that contain month/year dates are saved as character strings in a column with a <i>_month_year</i> suffix. A date-type estimate of the value (using the 1st of the month as the 'day') is stored in an adjacent column with the <i>_date</i> suffix. (This applies to date values in the <i>Studies</i> table.)</li>
-     <li>Derived/calculated values are stored in the <i>Calculated_Values</i> table.</i>
-   </ul>
-
-   <p>While we tried to rigorously adhere to these conventions, reality occasionally failed to cooperate, so compromises were made and exceptions to these rules exist. For example, to limit duplicate verbiage, we preferred the table name <i>References</i> over <i>Study_References</i>, however the word 'References' is a PostgreSQL reserved word and cannot be used as a table name, so <i>Study_References</i> it is.</p>
-
-   <h2 id='arms_groups'>How are arms/groups identified?</h2>
-   <p>Considerable thought went into how to present arm and group information to facilitate analysis by simplifying naming and data structures while retaining data fidelity.
-
-   NLM defines groups/arms this way:</p>
-   <ul class='regularDisplay'>
-     <li><i>Arm:</i> A pre-specified group or subgroup of participant(s) in a clinical trial assigned to receive specific intervention(s) (or no intervention) according to a protocol.</li>
-     <li><i>Group:</i> The predefined participant groups (cohorts) to be studied, corresponding to Number of Groups specified under Study Design (for single-group studies.</li>
-   </ul>
-
-   <p>In short, observational studies use the term ‘groups’; interventional studies use ‘arms’, though for the purpose of analysis, they both refer to the same thing. Because 'group' is more intuitive to the general public, AACT standardized on the term 'group(s)' and does not use the term 'arms'.</p>
-
-   <h4>Participant Groups: Registry vs Results</h4>
-   <p>When a study is registered in ClinicalTrials.gov, information is entered about how the study defines participant groups. In AACT, this information is stored in the <i>Design_Groups</i> table, while info about actual groups that is entered after the study has completed is stored in the <i>Result_Groups</i> table. (AACT has not attempted to link data between these 2 tables.)</p>
-
-   <p>Result information, for the most part, is organized in ClinicalTrials.gov by participant group. <i>Result_Contacts</i> & <i>Result_Agreements</i> are the only result tables not associated with groups. This section describes how AACT has structured group-related results data.</p>
-
-   <p>AACT provides four general categories of result information:</p>
-
-     <ul class='regularDisplay'>
-       <li>Participant Flow (Milestones & Drop/Withdrawals)</li>
-       <li>Baselines</li>
-       <li>Outcomes</li>
-       <li>Reported Events</li>
+  <section class="namingConventions" >
+    <h4 id='namingConventions'>Naming Conventions</h4>
+    <ul class='regularDisplay'>
+      <li>Table names are plural (e.g., <i>studies, facilities, interventions</i>).</li>
+      <li>Column names are singular (e.g., <i>description, phase, name</i>).</li>
+      <li>Multi-word names use underscores (e.g., <i>mesh_term, study_first_submitted_date</i>).</li>
+      <li>Case is ignored by PostgreSQL; <i>Studies</i>, <i>STUDIES</i>, and <i>studies</i> are equivalent.</li>
+      <li>Study design data from ClinicalTrials.gov use tables prefixed with <i>Design_</i>, distinguishing them from results tables (e.g., <i>Design_Groups</i> vs. <i>Result_Groups</i>).</li>
+      <li>Tables and columns use full names, avoiding abbreviations (e.g., <i>description</i> not <i>desc</i>).</li>
+      <li>Redundant wording is avoided (e.g., <i>Studies.source</i> instead of <i>Studies.study_source</i>).</li>
+      <li id='idInformation'>Columns ending with <i>_id</i> are foreign keys, linking the child table to the parent table's <i>id</i> column. For example:<br>
+        <i>Child_Table.parent_table_id = Parent_Table.id</i><br>
+        A row in <i>Facility_Contacts</i> links to its facility via <i>facility_id</i>:<br>
+        <i>Facility_Contacts.facility_id = Facilities.id</i>
+      </li>
     </ul>
 
-    <p>The <i>Result_Groups</i> table represents an aggregate list of all groups associated with these result types. All result tables (<i>Outcomes, Outcome_Counts, Baseline_Measures, Reported_Events</i>, etc.) relate to <i>Result_Groups</i> via the foreign key <i>result_group_id</i>.</p>
-    <p>For example, <i>Outcomes.result_group_id = Result_Groups.id</i>.</p>
+    <h4 id='structure_conventions'>Structural Conventions</h4>
+    <ul class='regularDisplay'>
+      <li>All tables include an <i>nct_id</i> column linking rows to the related study in the <i>Studies</i> table. (The schema diagram omits some lines to reduce complexity.)<br>
+        Example: <i>Studies.nct_id = Outcomes.nct_id</i> links outcomes to their study.</li>
+      <li>Every table has a primary key named <i>id</i>, except <i>Studies</i>, which uses <i>nct_id</i> as its primary key.</li>
+      <li>Columns ending in <i>_date</i> contain date-type values.</li>
+      <li>Columns with month/year dates are stored as strings with a <i>_month_year</i> suffix; an estimated date (using the 1st day of the month) is in an adjacent <i>_date</i> column. (Applies to <i>Studies</i> table.)</li>
+      <li>Derived or calculated values are stored in the <i>Calculated_Values</i> table.</li>
+    </ul>
 
-    <p>ClinicalTrials.gov assigns an identifier to each group/result that is unique within the study. The identifier includes two leading characters that represent the type of result (BG for Baseline, OG for Outcomes, EG for Reported Event, and FG for Participant Flow) followed by a three digit number starting with 000 that uniquely identifies the group in that context. To illustrate assume that study NCT001 had 2 groups: experimental & control, and reported multiple baseline measures, outcome measures, reported events and milestone/drop-withdrawals for each group. The following table illustrates how the <i>Result_Groups</i> table organizes the group information received from ClinicalTrials.gov in this case:</p>
-     <table id='resultGroup' class='regularDisplay'>
-       <tr>
-         <th class='resultGroup'>id</th>
-         <th class='resultGroup'>nct_id</th>
-         <th class='resultGroup'>result_type</th>
-         <th class='resultGroup'>ctgov_group_code</th>
-         <th class='resultGroup'>group title</th>
-         <th class='resultGroup'>explanation</th>
-       </tr>
-       <tr class='even'>
-         <td class='schemaID'>1</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Baseline</td>
-         <td class='schemaID'>BG000</td>
-         <td>Experimental Group</td>
-         <td>All Baseline_Measures associated with this study's experimental group link to this row.</th>
-       </tr>
-       <tr class='even'>
-         <td class='schemaID'>2</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Baseline</td>
-         <td class='schemaID'>BG001</td>
-         <td>Control Group</td>
-         <td>All Baseline_Measures associated with this study's control group link to this row.</td>
-       </tr>
-       <tr class='odd'>
-         <td class='schemaID'>3</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Outcome</td>
-         <td class='schemaID'>OG001</td>
-         <td>Experimental Group</td>
-         <td>All Outcome_Measures associated with this study's experimental group link to this row.</td>
-       </tr>
-       <tr class='odd'>
-         <td class='schemaID'>4</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Outcome</td>
-         <td class='schemaID'>OG000</td>
-         <td>Control Group</td>
-         <td>All Outcome_Measures associated with this study's control group link to this row.</td>
-       </tr>
-       <tr class='even'>
-         <td class='schemaID'>5</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Reported Event</td>
-         <td class='schemaID'>EG000</td>
-         <td>Experimental Group</td>
-         <td>All Reported_Events associated with this study's experimental group link to this row.</td>
-       </tr>
-       <tr class='even'>
-         <td class='schemaID'>6</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Reported Event</td>
-         <td class='schemaID'>EG001</td>
-         <td>Control Group</td>
-         <td>All Reported_Events associated with this study's control group link to this row.</td>
-       </tr>
-       <tr class='odd'>
-         <td class='schemaID'>7</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Participant Flow</td>
-         <td class='schemaID'>FG000</td>
-         <td>Experimental Group</td>
-         <td>All Milestones & Drop_Withdrawals associated with this study's experimental group link to this row.</td>
-       </tr>
-       <tr class='odd'>
-         <td class='schemaID'>8</td>
-         <td class='schemaID'>NCT001</td>
-         <td class='schemaID'>Participant Flow</td>
-         <td class='schemaID'>FG001</td>
-         <td>Control Group</td>
-         <td>All Milestones & Drop_Withdrawals associated with this study's studies control group link to this row.</td>
-       </tr>
-     </table>
+    <p>While these conventions are rigorously applied, exceptions exist. For example, the table <i>References</i> would have been preferred over <i>Study_References</i>, but since <i>References</i> is a PostgreSQL reserved word, <i>Study_References</i> is used instead.</p>
 
-     <p>
-      Notice that the integer in the code provided by ClinicalTrials.gov (ctgov_group_code) is often the same for one group across the different result types, but this is not always the case. In the example above, BG000, EG000 & FG000 all represent the 'experimental group', so you're tempted to think that '000' equates to to the 'experimental group' for this study, however for Outcomes, OG000 represents the control group. In short, the number in the ctgov_group_code often links the same group across all result types in a study, but for about 25% of studies, this is not the case, so it can't be counted on to indicate this relationship.
-     </p>
+    <h2 id='arms_groups'>How are arms/groups identified?</h2>
+    <div class="info-box"> 
+      <p>AACT simplifies arm and group data for easier analysis while preserving data integrity.</p>
 
-   <h2>Information about dates</h2>
-   <p>
-   When clinicaltrials.gov started tracking studies, it only tracked the month & year for some fields and not the day for several date values including start date, completion date, primary completion date and verification date. Because day is not provided for some studies, AACT stores these dates in the studies table as character type rather than date type values. Character type dates are of limited utility in an analytic database because they can’t be used to perform standard date calculations such as determining study duration or the average number of months for someone to report results or identify studies registered before/after a certain date.
-   </p>
-
-  <p>We provide 2 columns in the Studies table for each date element:</p>
-
-  <ol>
-    <li>A character-type column that displays the value exactly as it was received from ClinicalTrials.gov</li>
-    <li>A date-type column that can be used for date calculations.</li>
-  </ol>
-
-  <p>
-    If the date received from ClinicalTrials.gov has only month/year, in order to convert the string to a date, it is assigned the first day of the month. For example, a study with start date “June 2014” will have “June 2014” in the start_month_year column and “06/01/14” in the start_date column.
-  </p>
-
-    <div id='pending_results'>
-      <h2>Information about dates related to 'pending results'</h2>
-      <p>On May 9, 2018, the NLM added a new section of date information to the ClinicalTrials.gov API. The section is labeled "pendng_results" and serves to provide information about result submission activity while the results await quality control review.</p>
-
-      <p>NLM provides result submission date(s) for studies that have results awaiting quality control (QC) review. The results themselves are not publicly posted until the review is complete. The dates for three types of events related to results submission are reported in the Pending_Results table:</p>
+      <p>The National Library of Medicine (NLM) defines:</p>
       <ul class='regularDisplay'>
-
-        <li><i>Submission:</i> The date(s) that study results were submitted to NLM for QC review.</li>
-        <li><i>Submission Canceled:</i> The date(s) that such submissions were canceled by the data provider. (Note: this value is set to "Unknown" if the cancellation occurred before 05/08/2018 when this data started to be collected).</li>
-        <li><i>Returned:</i>  The date(s) that study results were returned to the data provider because they required modification.</li>
+        <li><i>Arm:</i> A pre-specified participant group assigned specific interventions per protocol.</li>
+        <li><i>Group:</i> Predefined participant cohorts studied, matching the Number of Groups in Study Design (for single-group studies).</li>
       </ul>
-      <p>The NLM reports that the following updates occur to this information when a study passes the quality control review:</p>
+
+      <p>Observational studies use “groups” and interventional studies use “arms,” but AACT standardizes on “group(s)” for clarity.</p>
+
+      <h4>Participant Groups: Registry vs. Results</h4>
+      <p>Registry info on participant groups is stored in <i>Design_Groups</i>. Post-study, actual group data are in <i>Result_Groups</i>. These tables are not linked in AACT.</p>
+
+      <p>Most results in ClinicalTrials.gov are organized by participant group. Except <i>Result_Contacts</i> and <i>Result_Agreements</i>, all results tables relate to groups.</p>
+
+      <p>AACT categorizes results into:</p>
       <ul class='regularDisplay'>
-
-        <li><i>Study.results_first_submitted_date</i> is populated with the earliest 'submitted date' from Pending_Results.</li>
-        <li><i>Study.results_first_submitted_qc_date</i> is populated with the submitted date of the version of results that passed QC.</li>
-        <li>Result tables (<i>Reported_Events, Outcomes, Baseline_Measurements</i>, etc.) are populated with the result information that passed QC.</li>
-        <li>All rows for the study with reviewed/approved results are removed from the <i>Pending_Events</i> table.</li>
+        <li>Participant Flow (Milestones & Drop/Withdrawals)</li>
+        <li>Baselines</li>
+        <li>Outcomes</li>
+        <li>Reported Events</li>
       </ul>
-      <p>More information about the quality control (QC) review process and how this information is presented in ClinicalTrials.gov can be found in the December, 2017 <a target='_blank' href='https://www.nlm.nih.gov/pubs/techbull/nd17/nd17_clinicaltrials_enhanced.html#anch_30'>NLM Technical Bulletin</a></p>
+
+      <p>The <i>Result_Groups</i> table aggregates all groups linked to these results. Related tables (e.g., <i>Outcomes</i>, <i>Baseline_Measures</i>) reference <i>Result_Groups</i> via <i>result_group_id</i>.<br>
+      Example: <i>Outcomes.result_group_id = Result_Groups.id</i>.</p>
+
+      <p>ClinicalTrials.gov assigns each group/result a unique identifier per study, starting with two letters for result type (BG, OG, EG, FG) followed by a three-digit code.</p>
+
+      <p>Example for study <i>NCT001</i> with experimental and control groups:</p>
+
+      <table id='resultGroup' class='regularDisplay'>
+        <tr>
+          <th>id</th><th>nct_id</th><th>result_type</th><th>ctgov_group_code</th><th>group title</th><th>explanation</th>
+        </tr>
+        <tr class='even'>
+          <td>1</td><td>NCT001</td><td>Baseline</td><td>BG000</td><td>Experimental Group</td><td>Baseline measures linked here.</td>
+        </tr>
+        <tr class='even'>
+          <td>2</td><td>NCT001</td><td>Baseline</td><td>BG001</td><td>Control Group</td><td>Baseline measures linked here.</td>
+        </tr>
+        <tr class='odd'>
+          <td>3</td><td>NCT001</td><td>Outcome</td><td>OG001</td><td>Experimental Group</td><td>Outcome measures linked here.</td>
+        </tr>
+        <tr class='odd'>
+          <td>4</td><td>NCT001</td><td>Outcome</td><td>OG000</td><td>Control Group</td><td>Outcome measures linked here.</td>
+        </tr>
+        <tr class='even'>
+          <td>5</td><td>NCT001</td><td>Reported Event</td><td>EG000</td><td>Experimental Group</td><td>Reported events linked here.</td>
+        </tr>
+        <tr class='even'>
+          <td>6</td><td>NCT001</td><td>Reported Event</td><td>EG001</td><td>Control Group</td><td>Reported events linked here.</td>
+        </tr>
+        <tr class='odd'>
+          <td>7</td><td>NCT001</td><td>Participant Flow</td><td>FG000</td><td>Experimental Group</td><td>Milestones & drop/withdrawals linked here.</td>
+        </tr>
+        <tr class='odd'>
+          <td>8</td><td>NCT001</td><td>Participant Flow</td><td>FG001</td><td>Control Group</td><td>Milestones & drop/withdrawals linked here.</td>
+        </tr>
+      </table>
+
+      <p>Note: The numeric part of <i>ctgov_group_code</i> often links the same group across result types (e.g., BG000, EG000, FG000 = Experimental Group). However, this is not consistent—about 25% of studies do not follow this pattern (e.g., OG000 may represent the control group). Thus, the code should not be solely relied upon to link groups across result types.</p>
     </div>
+
+    <h2>Information about dates</h2>
+    <p>Initially, ClinicalTrials.gov recorded only month and year (without day) for key dates like start date, completion date, primary completion date, and verification date. Because some dates lack day information, AACT stores these fields as character strings rather than date types, limiting their use in calculations (e.g., study duration or date comparisons).</p>
+
+    <p>To address this, each date element in the <i>Studies</i> table has two columns:</p>
+    <ol>
+      <li>A character-type column showing the original ClinicalTrials.gov value.</li>
+      <li>A date-type column suitable for calculations.</li>
+    </ol>
+
+    <p>When only month and year are provided, the date-type column defaults to the first day of that month. For example, “June 2014” is stored as “June 2014” in the character column and as “06/01/2014” in the date column.</p>
+
+    <div id='pending_results' class="info-box"> 
+      <h2>Information about dates related to pending results</h2>
+      <p>On May 9, 2018, NLM added the <i>pending_results</i> section to the ClinicalTrials.gov API. It tracks dates for result submissions undergoing quality control (QC) review before public posting.</p>
+
+      <p>The <i>Pending_Results</i> table records three event types:</p>
+      <ul class='regularDisplay'>
+        <li><i>Submission:</i> Date(s) study results were submitted for QC review.</li>
+        <li><i>Submission Canceled:</i> Date(s) submissions were canceled by the data provider. (Before 05/08/2018, cancellations are marked "Unknown.")</li>
+        <li><i>Returned:</i> Date(s) results were returned to the provider for modification.</li>
+      </ul>
+
+      <p>When a study passes QC review, NLM updates:</p>
+      <ul class='regularDisplay'>
+        <li><i>Studies.results_first_submitted_date</i> with the earliest submission date from <i>Pending_Results</i>.</li>
+        <li><i>Studies.results_first_submitted_qc_date</i> with the submission date of the QC-approved results.</li>
+        <li>Result tables (e.g., <i>Reported_Events, Outcomes, Baseline_Measurements</i>) with the approved data.</li>
+        <li>Removes all approved result rows for that study from <i>Pending_Results</i>.</li>
+      </ul>
+
+      <p>For more on QC and this data, see the December 2017 <a target='_blank' href='https://www.nlm.nih.gov/pubs/techbull/nd17/nd17_clinicaltrials_enhanced.html#anch_30'>NLM Technical Bulletin</a>.</p>
+    </div>
+
 
     <div id='trial_sites'>
       <h2>Information about trial sites (Facilities and Countries)</h2>
-      <p> Information about organizations where the study is/was conducted (aka. facilities, trial sites) is stored in the <i>Facilities</i> table. This represents the facility information that was included in the study record on the date that information was downloaded from ClinicalTrials.gov.</p>
+      <p>The <i>Facilities</i> table stores information about organizations where the study is or was conducted, reflecting data from ClinicalTrials.gov at download time.</p>
 
-      <p>The name and email/phone for the contact person (and optionally, a backup contact) at a facility is available if the facility status (<i>Facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’, and if the data provider has provided such information. This information is stored in AACT in the <i>Facility_Contacts</i> table, which is a ‘child’ of the <i>Facilities</i> table. Facility-level contact information is not required if a central contact has been provided. Contact information is removed from the publicly available content at ClinicalTrials.gov (and therefore from AACT) when the facility is no longer recruiting, or when the overall study status (<i>Studies.overall_status</i>) changes to indicate that the study has completed recruitment.</p>
+      <p>Contact details (name, email, phone) for a facility’s primary and optional backup contacts are available only if the facility’s status (<i>Facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’ and if provided by the data submitter. This information is stored in the <i>Facility_Contacts</i> table, a child of <i>Facilities</i>. Contact info is removed when a facility stops recruiting or when the overall study status (<i>Studies.overall_status</i>) indicates recruitment completion.</p>
 
-      <p>Similarly, the names and roles of investigators at the facility are available if the facility status (<i>Facilities.status</i>) is ‘<i>Recruiting</i>’ or ‘<i>Not yet recruiting</i>’, and if the data provider has provided such information. This information is stored in AACT in the <i>Facility_Investigators</i> table, which is a ‘child’ of the <i>Facilities</i> table. Facility-level investigator information is optional. Facility-level investigator information is removed from the publicly available content at ClinicalTrials.gov (and therefore from AACT) when the facility is no longer recruiting, or when the overall study status (<i>Studies.overall_status</i>) changes to indicate that the study has completed recruitment. </p>
+      <p>Similarly, investigator names and roles at facilities (stored in <i>Facility_Investigators</i>, another child table) are available under the same conditions and are removed once recruiting ends.</p>
 
-      <p>AACT includes a <i>Countries</i> table, which contains one record per unique country per study. The <i>Countries</i> table includes countries currently & previously associated with the study. The <i>removed</i> column identifies those countries that are no longer associated with the study. NLM uses facilities information to create a list of unique countries associated with the study. In some cases, ClinicalTrials.gov data submitters subsequently remove facilities that were entered when the study was registered. Naturally these will not appear in AACT's <i>Facilities</i> table. If all of a country’s facilities have been removed from a study, NLM flags the country as ‘Removed’ which appears in AACT as <i>Countries.removed</i> = true.
+      <p>The <i>Countries</i> table lists unique countries per study, including those currently and previously associated. The <i>removed</i> column flags countries no longer linked to the study. This occurs when all facilities in a country are deleted from a study, which may happen for various reasons, such as incorrect data or uninitiated sites.</p>
 
-      <p>The reasons facilities are removed are varied and unknown. A site may have been removed because it was never initiated or because it was entered with incorrect information. The recommended action for sites that have completed or have terminated enrollment is to change the enrollment status to “Completed” or “Terminated”; however, such sites are sometimes deleted from the study record by the responsible party. Data analysts may consider using Countries where <i>removed</i> is set to true to supplement the information about trial locations that is contained in <i>Facilities</i>, particularly for studies that have completed enrollment and have no records in <i>Facilities</i>.</p>
+      <p>Since removed facilities do not appear in <i>Facilities</i>, analysts can use the <i>Countries</i> table (including those marked as removed) to supplement trial location data, especially for studies that have completed enrollment.</p>
 
-      <p>Users who are interested in identifying countries where participants are being/were enrolled may use either the <i>Facilities</i> or <i>Countries</i> (where <i>Countries.removed</i> is not true) with equivalent results.</p>
+      <p>For identifying countries with participant enrollment, using either <i>Facilities</i> or <i>Countries</i> (where <i>removed</i> is false) provides equivalent results.</p>
     </div>
 
-    <div id='delayed_results'>
-      <h2>“Delayed Results” data elements are available in AACT</h2>
-      <p>A responsible party of an applicable clinical trial may delay the deadline for submitting results information to ClinicalTrials.gov for up to two additional years if one of the following two certification conditions applies to the trial:</p>
+
+    <div id='delayed_results'class="info-box"> 
+      <h2>“Delayed Results” data elements in AACT</h2>
+      <p>A responsible party may delay the results submission deadline for up to two years if one of these conditions applies:</p>
 
       <ul class='regularDisplay'>
-        <li>Initial approval: trial completed before a drug, biologic or device studied in the trial is initially approved, licensed or cleared by the FDA for any use.</li>
-        <li>New use: the manufacturer of a drug, biologic or device is the sponsor of the trial and has filed or will file within one year, an application seeking FDA approval, licensure, or clearance of the new use studied in the trial. A responsible party may also request, for good cause, an extension of the deadline for the submission of results.</li>
+        <li>The trial completed before the FDA initially approved, licensed, or cleared the studied drug, biologic, or device for any use.</li>
+        <li>The trial’s sponsor has filed or will file within one year an FDA application for approval, licensure, or clearance of the new use studied. Extensions may be granted for good cause.</li>
       </ul>
 
-      <p>Studies for which a certification or extension request have been submitted include the date of the first certification or extension request in the data element: <i>Studies.disposition_first_submitted_date</i>.</p>
-
+      <p>Studies with certification or extension requests record the submission date in <i>Studies.disposition_first_submitted_date</i>.</p>
     </div>
 
-</section>
+  </section>
 </main>

--- a/app/views/pages/points_to_consider.html.erb
+++ b/app/views/pages/points_to_consider.html.erb
@@ -5,148 +5,98 @@
 
     <h2>What is AACT?</h2>
 
-    <p class='ptc'>AACT is the database for Aggregate Analysis of <a target='_blank' href="https://clinicaltrials.gov"  onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">ClinicalTrials.gov</a>. This version of AACT is a PostgreSQL relational database containing information about clinical studies that have been been registered at ClinicalTrials.gov. AACT includes all of the protocol and results data elements for studies that are publicly available at ClinicalTrials.gov. Content is downloaded daily from ClinicalTrials.gov and loaded into AACT.</p>
+<div class="info-box">
+  <p class='ptc'>
+    AACT (Aggregate Analysis of 
+    <a target='_blank' href="https://clinicaltrials.gov" onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">
+      ClinicalTrials.gov
+    </a>) is a publicly available PostgreSQL database maintained by the Clinical Trials Transformation Initiative (CTTI). It contains a structured version of all study records from ClinicalTrials.gov.
+  </p>
 
-    <h2>What population of studies is represented in AACT?</h2>
+  <dl class='ptc'>
+    <dt><b>Updated Daily:</b></dt>
+    <dd>New and changed study records are added nightly based on the ClinicalTrials.gov RSS feed and API.</dd>
 
-    <p class='ptc'>All studies registered and publicly available in ClinicalTrials.gov are included in AACT. The ClinicalTrials.gov was released for the registration of studies on <b>February 29, 2000</b>. The registry accepts interventional studies in which participants are assigned according to a research protocol to receive specific interventions, as well as observational studies. It also includes Expanded Access records which describe the procedure for obtaining an experimental drug or device for patients who are not adequately treated by existing therapy and who are unable to participate in a controlled clinical study.</p>
+    <dt><b>Full Monthly Refresh:</b></dt>
+    <dd>The entire database is rebuilt once a month to capture deletions and ensure completeness.</dd>
 
-    <p class='ptc'>The registration of studies and reporting of results and adverse events has been mandated to a large extent by requirements (both legal and institutional) implemented as part of the Food and Drug Administration Amendments Act (FDAAA), as well as by requirements introduced by the International Committee of Medical Journal Editors (<a target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/'  onClick="ga('send','event','external link','guide page: ICMJE')">ICMJE</a>), the European Medicines Agency (EMA) and the National Institutes of Health (NIH) regarding registration and reporting of results of clinical studies. Table 1 describes the scope of these requirements.</p>
+    <dt><b>Structured Format:</b></dt>
+    <dd>AACT transforms XML records into a relational database with organized tables and fields.</dd>
 
-    <h4>Table 1: Scope of Interventional Studies Covered by Major Reporting Policies*</h4>
+    <dt><b>Open Access:</b></dt>
+    <dd>Anyone can query the data using SQL or download full database dumps.</dd>
+  </dl>
+</div>
 
-  <table id='pointsToConsider' class='regularDisplay'>
-    <thead>
-      <th>Policy</th>
-      <th>Registration & Results Reporting Requirements</th>
-      <th>Effective Date(s)</th>
-    </thead>
+<h2>What population of studies is represented in AACT?</h2>
 
-    <tbody>
-      <tr class='even'>
-        <td><p class='ptc'><a target='_blank' href='https://www.federalregister.gov/documents/2016/09/21/2016-22379/nih-policy-on-the-dissemination-of-nih-funded-clinical-trial-information' onClick="ga('send','event','external link','guide page: NIH Policy')">NIH Policy</a></p></td>
-        <td><p class='ptc'>Every clinical trial funded in whole or in part by NIH is expected to be registered on ClinicalTrials.gov and have summary results information submitted and posted in a timely manner, whether subject to FDAAA 801 or not.</p></td>
-  January 18, 2017. The policy is effective for applications for funding, including grants, other transactions, and contracts submitted on or after January 18, 2017. For the NIH intramural program, the policy applies to clinical trials initiated on or after January 18, 2017.
-          <br>
-  Timelines for registration and results/adverse event reporting are the same as for trials subject to FDAAA 801.
-        <td>
-           <p class='ptc'><b>January 18, 2017.</b> The policy is effective for applications for funding, including grants, other transactions, and contracts submitted on or after January 18, 2017. For the NIH intramural program, the policy applies to clinical trials initiated on or after January 18, 2017. Timelines for registration and results/adverse event reporting are the same as for trials subject to FDAAA 801.</p>
-        </td>
-      </tr>
+<div class="info-box">
+  <p class='ptc'>
+    AACT includes all publicly available study records from ClinicalTrials.gov, across various types:
+  </p>
 
-      <tr class='odd'>
-        <td><a target='_blank' href='https://grants.nih.gov/grants/guide/notice-files/NOT-CA-15-011.html' onClick="ga('send','event','external link','guide page: NCI Access Policy')">NCI Access Policy</a></p></td>
-        <td><p class='ptc'>The NCI issued its <i>Policy Ensuring Public Availability of Results from NCI-supported Clinical Trials</i>. Generally, for "all initiated or commenced NCI-Supported Interventional Clinical Trials whether extramural or intramural" (Covered Trials), "Final Trial Results are expected to be reported in a publicly accessible manner within 12 months of the Trial's Primary Completion Date regardless of whether the clinical trial was completed as planned or terminated earlier." This policy "will be incorporated as a Term and Condition of the award."</p></td>
-        <td><p class='ptc'><b>January, 2015</b></p></td>
-    </tr>
+  <ul class='regularDisplay'>
+    <li>Interventional trials (e.g., drug/device studies)</li>
+    <li>Observational studies</li>
+    <li>Expanded access programs</li>
+  </ul>
 
-    <tr class='even'>
-      <td><a target='_blank' href='http://www.fda.gov/RegulatoryInformation/Legislation/SignificantAmendmentstotheFDCAct/FoodandDrugAdministrationAmendmentsActof2007/default.htm' onClick="ga('send','event','external link','guide page: FDAAA')">FDAAA and Final Rule</a></td>
-      <td>
-        <p class='ptc'>The following must be registered in ClinicalTrials.gov ('Applicable Clinical Trials (ACTs)':
-        <ul class='regularDisplay'>
-          <li>Interventional studies of drugs, biologics, or devices (whether or not approved for marketing)</li>
-          <li>Studies phases 2 through 4</li>
-          <li>Studies with at least 1 US site or conducted under IND/IDE</li>
-        </ul>
-        </p>
+  <p class='ptc'>
+    Several global policies drive study registration and results reporting. These include:
+  </p>
 
-        <p class='ptc'>
-        Results and adverse event reporting is required for studies that meet the above registration requirements if they study drugs, biologics, or devices that are approved, licensed, or cleared by the FDA.
-        </p>
-        <p class='ptc'>
-        The <a target='_blank' href='http://www.nejm.org/doi/full/10.1056/NEJMsr1611785' onClick="ga('send','event','external link','guide page: Final Rules')">Final Rule</a> clarified the definition of an ACT, and expanded results and adverse events reporting requirements to include ACTs of unapproved products.
-        </p>
-      </td>
+  <ul class='regularDisplay'>
+    <li><b>FDAAA 801 (2007) & Final Rule (2017)</b> — U.S. laws requiring certain trials to register and report results.</li>
+    <li><b>NIH Policy (2016)</b> — Extends reporting expectations to all NIH-funded studies.</li>
+    <li><b>ICMJE Policy</b> — Requires trial registration for publication eligibility in participating journals.</li>
+    <li><b>EMA (2014) and NCI Requirements</b> — Encourage transparency in clinical research.</li>
+  </ul>
+</div>
 
-      <td>
-        <p class='ptc'><b>September 27, 2007.</b> Studies initiated after this date, or with a completion date later than December 25, 2007 are subject to FDAAA requirements. Registration is required no later than 21 days after first patient is enrolled. Results and adverse events must be reported for these studies (if required) within 1 year of completing data collection for the pre-specified primary outcome.
-        <br><br>
-        For ACTs of devices not previously approved or cleared by FDA, public posting of registration information is delayed until after FDA approval/clearance.
-        <br><br>
-        <b>September, 2008.</b> Results reporting launched with optional adverse event reporting.
-        <br><br>
-        <b>September, 2009.</b>  Adverse event information became required.
-        <p class='ptc'><b>January 18, 2017.</b> Final Rule for FDAAA 801 effective, with compliance expected as of April 18, 2017. </p>
-        <ul class='regularDisplay'>
-          <li>Responsible parties of ACTs of devices not previously cleared or approved by FDA may authorize NIH to post registration information prior to FDA approval/ clearance.</li>
-          <li>For ACTs of unapproved products, results reporting may be delayed for up to 2 additional years (i.e., up to 3 years total after the primary completion date).</li>
-        </ul>
-         </p>
-      </td>
-    </tr>
+<h2>Is the information in AACT up-to-date?</h2>
 
-    <tr class='odd'>
-      <td><a target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/' onClick="ga('send','event','external link','guide page: ICMJE')">ICMJE</a></td>
-      <td><p class='ptc'>
-        Interventional studies of any intervention type, phase, or geographical location must be registered in ClinicalTrials.gov or other approved registry.
-        <br>No results reporting requirements.
-        </p>
-      </td>
-      <td><p class='ptc'><b>July 1, 2005</b>. Studies initiated after this date must be registered before first patient enrolled; studies initiated before this date must be retrospectively registered to be considered for publication.
-        </p>
-      </td>
-    </tr>
+<div class="info-box">
+  <h4>Nightly Updates</h4>
+  <p class='ptc'>
+    Every night around midnight (U.S. Eastern Time), new or modified study records from ClinicalTrials.gov are imported into a background version of AACT. After validation, the updated database is copied to the public AACT database, usually within 90 minutes.
+  </p>
+  <p class='ptc'>
+    During this brief copy process (typically 5 minutes), AACT is unavailable.
+  </p>
 
-    <tr class='even'>
-      <td><a target='_blank' href='https://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000629.jsp&mid=WC0b01ac05808768df' onClick="ga('send','event','external link','guide page: EMA')">EMA</a></td>
-      <td>
-        <p class='ptc'>The following must be registered in ClinicalTrials.gov or other approved registry:
-        <ul class='regularDisplay'>
-          <li>Interventional studies of drugs or biologics (whether or not approved for marketing)</li>
-          <li>Pediatric phase 1 studies;</li>
-          <li>Studies in phases 2 through 4</li>
-          <li>Studies taking place in at least 1 EU site</li>
-        </ul>
-        </p>
-        <p class='ptc'>Results reporting required for all studies that meet registration requirements.</p>
-      </td>
-      <td>
-          <p>
-            <b>May 1, 2004</b>. <a target='_blank' href='http://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000629.jsp&mid=WC0b01ac05808768df'  onClick="ga('send','event','external link','guide page: EMA')">EMA</a> launched <a target='_blank' href='https://eudract.ema.europa.eu/'  onClick="ga('send','event','external link','guide page: EudraCT')">EudraCT</a>
-            <br><br>
-            <b>March 22, 2011</b>. <a target='_blank' href='http://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000629.jsp&mid=WC0b01ac05808768df' onClick="ga('send','event','external link','guide page: EMA')">EMA</a> launched the <a target='_blank' href='https://www.clinicaltrialsregister.eu/' onClick="ga('send','event','external link','guide page: EU Clinical Trials Register')">EU Clinical Trials Register</a>
-            <br><br>
-            <b>October 11, 2013</b>. EMA expanded EudraCT to include summary results.
-         </p>
-      </td>
-    </tr>
-  </tbody>
-</table>
+  <h4>Monthly Refresh</h4>
+  <p class='ptc'>
+    Once a month, AACT is completely rebuilt from scratch using the entire ClinicalTrials.gov dataset. This ensures:
+  </p>
+  <ul class='regularDisplay'>
+    <li>Deleted studies (those removed from ClinicalTrials.gov) are reflected.</li>
+    <li>Data integrity is maintained across all tables and fields.</li>
+  </ul>
+</div>
 
+<h2>How are unique studies identified in AACT?</h2>
+
+<p class='ptc'>
+  Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  
+  Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, 
+  we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinicalTrials.gov refers to a unique clinical study, 
+  however a small number of 
+  <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>
+    duplicate records may exist in the database.
+  </a>
 </p>
-<p class='ptcFootNote'>* Adapted from <a class='ptcFootNote' target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article">The ClinicalTrials.gov results database – update and key issues</a> and <a class='ptcFootNote' target='_blank' href='https://clinicaltrials.gov/ct2/about-site/history'>ClinicalTrials.gov summary of selected events, policies, and laws related to the development and expansion of ClinicalTrials.gov</a>. For complete descriptions of policy requirements, see the references cited. <a class='ptcFootNote' target='_blank' href='http://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000629.jsp&mid=WC0b01ac05808768df'>EMA</a> denotes European Medicines Agency; EU, European Union; FDAAA, Food and Drug Administration Amendments Act; <a class='ptcFootNote' target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/'>ICMJE</a>, International Committee of Medical Journal Editors; IDE, investigational device exemption; IND, investigational new drug application, NCI, National Cancer Institute; NIH, National Institutes of Health; US, United States.</p>
 
-    <p class='ptc'>Based on these policies, the following are examples of characteristics that may influence the likelihood that a study is included in the ClinicalTrials.gov registry:</p>
+<h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
 
-    <ul class='regularDisplay'>
-      <li>Interventional studies are more likely to be registered than observational studies.</li>
-      <li>Studies that began before the <a target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/'>ICMJE</a> requirement in <b>July, 2005</b> are less likely to be registered, especially if their results are unpublished (e.g., negative studies).</li>
-      <li>Studies with drug, biological, or device interventions are more likely to be registered than studies of other interventions.</li>
-      <li>Studies with at least one site in the United States or European Union are more likely to be registered than studies with no such sites.</li>
-      <li>Studies involving a drug or device that is manufactured in the United States are more likely to be registered than studies involving a drug or device manufactured outside of the United States.</li>
-      <li>Studies subject to an IND or IDE are more likely to be registered (i.e., if the study is intended to support approval for marketing in the United States).</li>
-      <li>Phase 1 adult drug studies or small feasibility studies of devices are less likely to be registered.</li>
-      <li>Studies in pediatric populations may be more likely to be registered.</li>
-      <li>Studies with NIH funding are likely to be registered, regardless of intervention and phase.</li>
-      <li>Although studies of FDA regulated devices are likely to be registered, the registration records for studies of devices not yet approved or cleared may not be publicly posted until after the device is cleared or approved.</li>
-    </ul>
+<div class="info-box">
+  <p class='ptc'>
+    AACT contains the same publicly available study data as ClinicalTrials.gov but stores it in a structured, relational database format.
+  </p>
+  <p class='ptc'>
+    It reflects only the most current version of each study record and does not preserve historical edits. While the core content remains unchanged, AACT includes some derived fields (like those in the calculated_values table) to make querying and analysis easier.
+  </p>
+</div>
 
-     <h2>Is the information in AACT up-to-date?</h2>
-
-     <p class='ptc'>The AACT database is updated every night at midnight, so the information in AACT is one day behind that which appears in ClinicalTrials.gov. The nightly update process uses the ClinicalTrials.gov RSS feed to identify studies that were added or changed in ClinicalTrials.gov the previous day, and then uses the ClinicalTrials.gov API to retrieve current data for just these studies. Only new/changed studies are created/modified. This process takes about one and a half hours, depending on how many studies were added/changed in ClinicalTrials.gov the previous day.</p>
-     <p class='ptc'>Occassionally, studies must be removed from ClinicalTrials.gov, such as those that were accidentally entered twice. The nightly update process does not detect removed studies so once a month, the AACT database is dropped and completely refreshed.</p>
-     <p class='ptc'>Both the nightly (incremental) and monthly (full) updates are performed on a 'background' database so that the publicly accessible database remains accessible while updates take place. When the process completes, the updated version is copied to the public database. This 'copy step' takes about 5 minutes, during which time the database is inaccessible. Since the nightly load starts at midnight and takes about one and a half hours, this 5-minute downtime usually occurs sometime between 1am & 2am.</p>
-     <p class='ptc'>Please refer to the posted <a target='_blank' href='/update_policy'>update schedule</a> for more details.</p>
-
-     <h2>How are unique studies identified in AACT?</h2>
-
-     <p class='ptc'>Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinialTrials.gov refers to a unique clinical study, however a small number of <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>duplicate records may exist in the database.</a></p>
-
-    <h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
-
-    <p class='ptc'>AACT includes all protocol and results data for every study that is publicly available at ClinicalTrials.gov. All publicly available content from the current record for a study is included in AACT as it appears in ClinicalTrials.gov. The AACT database preserves the content from the source XML files downloaded from the ClinicalTrials.gov API; content is not cleaned or manipulated in any way. However, to help facilitate queries using AACT, several additional variables derived from the raw content are included in AACT's Calculated_Values table.</p>
-    <p class='ptc'>The history of changes to a study record (available at the ClinicalTrials.gov archive site) is not included in the current version of AACT.</p>
 
     <h2>What types of questions can be investigated using ClinicalTrials.gov data?</h2>
 

--- a/app/views/pages/points_to_consider.html.erb
+++ b/app/views/pages/points_to_consider.html.erb
@@ -3,197 +3,216 @@
 
 <section class="pointsToConsider">
 
-    <h2>What is AACT?</h2>
+  <h2>What is AACT?</h2>
 
-<div class="info-box">
+  <div class="info-box">
+    <p class='ptc'>
+      AACT (Aggregate Analysis of 
+      <a target='_blank' href="https://clinicaltrials.gov" onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">
+        ClinicalTrials.gov
+      </a>) is a publicly available PostgreSQL database maintained by the Clinical Trials Transformation Initiative (CTTI). It contains a structured version of all study records from ClinicalTrials.gov.
+    </p>
+
+    <dl class='ptc'>
+      <dt><b>Updated Daily:</b></dt>
+      <dd>New and changed study records are added nightly based on the ClinicalTrials.gov RSS feed and API.</dd>
+
+      <dt><b>Full Monthly Refresh:</b></dt>
+      <dd>The entire database is rebuilt once a month to capture deletions and ensure completeness.</dd>
+
+      <dt><b>Structured Format:</b></dt>
+      <dd>AACT transforms XML records into a relational database with organized tables and fields.</dd>
+
+      <dt><b>Open Access:</b></dt>
+      <dd>Anyone can query the data using SQL or download full database dumps.</dd>
+    </dl>
+  </div>
+
+  <h2>What population of studies is represented in AACT?</h2>
+
+  <div class="info-box">
+    <p class='ptc'>
+      AACT includes all publicly available study records from ClinicalTrials.gov, across various types:
+    </p>
+
+    <ul class='regularDisplay'>
+      <li>Interventional trials (e.g., drug/device studies)</li>
+      <li>Observational studies</li>
+      <li>Expanded access programs</li>
+    </ul>
+
+    <p class='ptc'>
+      Several global policies drive study registration and results reporting. These include:
+    </p>
+
+    <ul class='regularDisplay'>
+      <li><b>FDAAA 801 (2007) & Final Rule (2017)</b> — U.S. laws requiring certain trials to register and report results.</li>
+      <li><b>NIH Policy (2016)</b> — Extends reporting expectations to all NIH-funded studies.</li>
+      <li><b>ICMJE Policy</b> — Requires trial registration for publication eligibility in participating journals.</li>
+      <li><b>EMA (2014) and NCI Requirements</b> — Encourage transparency in clinical research.</li>
+    </ul>
+  </div>
+
+  <h2>Is the information in AACT up-to-date?</h2>
+
+  <div class="info-box">
+    <h4>Nightly Updates</h4>
+    <p class='ptc'>
+      Every night around midnight (U.S. Eastern Time), new or modified study records from ClinicalTrials.gov are imported into a background version of AACT. After validation, the updated database is copied to the public AACT database, usually within 90 minutes.
+    </p>
+    <p class='ptc'>
+      During this brief copy process (typically 5 minutes), AACT is unavailable.
+    </p>
+
+    <h4>Monthly Refresh</h4>
+    <p class='ptc'>
+      Once a month, AACT is completely rebuilt from scratch using the entire ClinicalTrials.gov dataset. This ensures:
+    </p>
+    <ul class='regularDisplay'>
+      <li>Deleted studies (those removed from ClinicalTrials.gov) are reflected.</li>
+      <li>Data integrity is maintained across all tables and fields.</li>
+    </ul>
+  </div>
+
+  <h2>How are unique studies identified in AACT?</h2>
+
   <p class='ptc'>
-    AACT (Aggregate Analysis of 
-    <a target='_blank' href="https://clinicaltrials.gov" onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">
-      ClinicalTrials.gov
-    </a>) is a publicly available PostgreSQL database maintained by the Clinical Trials Transformation Initiative (CTTI). It contains a structured version of all study records from ClinicalTrials.gov.
+    Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  
+    Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, 
+    we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinicalTrials.gov refers to a unique clinical study, 
+    however a small number of 
+    <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>
+      duplicate records may exist in the database.
+    </a>
   </p>
 
-  <dl class='ptc'>
-    <dt><b>Updated Daily:</b></dt>
-    <dd>New and changed study records are added nightly based on the ClinicalTrials.gov RSS feed and API.</dd>
+  <h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
 
-    <dt><b>Full Monthly Refresh:</b></dt>
-    <dd>The entire database is rebuilt once a month to capture deletions and ensure completeness.</dd>
-
-    <dt><b>Structured Format:</b></dt>
-    <dd>AACT transforms XML records into a relational database with organized tables and fields.</dd>
-
-    <dt><b>Open Access:</b></dt>
-    <dd>Anyone can query the data using SQL or download full database dumps.</dd>
-  </dl>
-</div>
-
-<h2>What population of studies is represented in AACT?</h2>
-
-<div class="info-box">
-  <p class='ptc'>
-    AACT includes all publicly available study records from ClinicalTrials.gov, across various types:
-  </p>
-
-  <ul class='regularDisplay'>
-    <li>Interventional trials (e.g., drug/device studies)</li>
-    <li>Observational studies</li>
-    <li>Expanded access programs</li>
-  </ul>
-
-  <p class='ptc'>
-    Several global policies drive study registration and results reporting. These include:
-  </p>
-
-  <ul class='regularDisplay'>
-    <li><b>FDAAA 801 (2007) & Final Rule (2017)</b> — U.S. laws requiring certain trials to register and report results.</li>
-    <li><b>NIH Policy (2016)</b> — Extends reporting expectations to all NIH-funded studies.</li>
-    <li><b>ICMJE Policy</b> — Requires trial registration for publication eligibility in participating journals.</li>
-    <li><b>EMA (2014) and NCI Requirements</b> — Encourage transparency in clinical research.</li>
-  </ul>
-</div>
-
-<h2>Is the information in AACT up-to-date?</h2>
-
-<div class="info-box">
-  <h4>Nightly Updates</h4>
-  <p class='ptc'>
-    Every night around midnight (U.S. Eastern Time), new or modified study records from ClinicalTrials.gov are imported into a background version of AACT. After validation, the updated database is copied to the public AACT database, usually within 90 minutes.
-  </p>
-  <p class='ptc'>
-    During this brief copy process (typically 5 minutes), AACT is unavailable.
-  </p>
-
-  <h4>Monthly Refresh</h4>
-  <p class='ptc'>
-    Once a month, AACT is completely rebuilt from scratch using the entire ClinicalTrials.gov dataset. This ensures:
-  </p>
-  <ul class='regularDisplay'>
-    <li>Deleted studies (those removed from ClinicalTrials.gov) are reflected.</li>
-    <li>Data integrity is maintained across all tables and fields.</li>
-  </ul>
-</div>
-
-<h2>How are unique studies identified in AACT?</h2>
-
-<p class='ptc'>
-  Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  
-  Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, 
-  we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinicalTrials.gov refers to a unique clinical study, 
-  however a small number of 
-  <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>
-    duplicate records may exist in the database.
-  </a>
-</p>
-
-<h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
-
-<div class="info-box">
-  <p class='ptc'>
-    AACT contains the same publicly available study data as ClinicalTrials.gov but stores it in a structured, relational database format.
-  </p>
-  <p class='ptc'>
-    It reflects only the most current version of each study record and does not preserve historical edits. While the core content remains unchanged, AACT includes some derived fields (like those in the calculated_values table) to make querying and analysis easier.
-  </p>
-</div>
+  <div class="info-box">
+    <p class='ptc'>
+      AACT contains the same publicly available study data as ClinicalTrials.gov but stores it in a structured, relational database format.
+    </p>
+    <p class='ptc'>
+      It reflects only the most current version of each study record and does not preserve historical edits. While the core content remains unchanged, AACT includes some derived fields (like those in the calculated_values table) to make querying and analysis easier.
+    </p>
+  </div>
 
 
-    <h2>What types of questions can be investigated using ClinicalTrials.gov data?</h2>
+  <h2>What types of questions can be investigated using ClinicalTrials.gov data?</h2>
 
-    <p class='ptc'>The AACT database contains both ‘study protocol’ and ‘results data’ elements. The protocol (or registration) records describe the study characteristics including sponsor, disease condition, type of intervention, participant eligibility, anticipated enrollment, study design, locations, and outcome measures. Summary results data elements including participant flow, baseline characteristics, outcome results, and frequencies of serious and other adverse events are included in AACT.  The <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/'>article by Tse et al</a> may be helpful in understanding the components of the basic results that are reported at ClinicalTrials.gov.</p>
+  <p class='ptc'>The AACT database contains both ‘study protocol’ and ‘results data’ elements. The protocol (or registration) records describe the study characteristics including sponsor, disease condition, type of intervention, participant eligibility, anticipated enrollment, study design, locations, and outcome measures. Summary results data elements including participant flow, baseline characteristics, outcome results, and frequencies of serious and other adverse events are included in AACT.  The <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/'>article by Tse et al</a> may be helpful in understanding the components of the basic results that are reported at ClinicalTrials.gov.</p>
 
+  <div class="info-box">
     <h2>How can protocol/registration data be used?</h2>
 
-    <p class='ptc'>We anticipate that investigators will use the current database to explore the characteristics of selected subsets of clinical studies (e.g., typical enrollment for a phase 3 study in breast cancer patients), and to compare and contrast these characteristics across different subgroups of studies (e.g., sponsor; device versus drug intervention; or prevention versus treatment).</p>
+    <p class='ptc'>Researchers can use protocol data from AACT to explore and compare the characteristics of different groups of clinical studies. For example, you might examine typical enrollment sizes for phase 3 breast cancer trials or analyze differences between studies based on sponsor type, intervention (e.g., drug vs. device), or purpose (e.g., prevention vs. treatment).</p>
+  </div>
 
-    <h2>How can results and adverse events data be used?</h2>
+  <h2>How can results and adverse events data be used?</h2>
 
-    <p class='ptc'>Researchers may be able to use the basic results and adverse events summary data reported at ClinicalTrials.gov for meta-analysis or systematic review (e.g., to compare the efficacy and safety of different types of diabetes therapies).  However, because only a small subset of studies registered at ClinicalTrials.gov are required to report results, the results data from ClinicalTrials.gov will most likely be a useful supplement to traditional data sources used for a meta-analysis or systematic review, such as published and unpublished manuscripts and abstracts, rather than the core data source. Standard techniques for valid meta-analysis or systematic review (e.g., <a target='_blank' href="http://annals.org/article.aspx?articleid=744664">PRISMA statement</a>) should be used when determining how to appropriately identify and aggregate summary data gleaned from ClinicalTrials.gov and/or literature.)</p>
+  <p class='ptc'>Researchers can use results and adverse events data from AACT to support meta-analyses or systematic reviews—for example, comparing the safety and effectiveness of different diabetes treatments. However, because only a subset of studies on ClinicalTrials.gov are required to report results, this data often serves as a supplement rather than a primary source. When using these data for research, it’s important to follow standard guidelines for systematic reviews, such as the PRISMA statement.</p>
 
+  <div class="info-box">
     <h2>How should data elements be interpreted?</h2>
-
-    <p class='ptc'>When interpreting this information, you’re encouraged to refer to the authoritative definitions provided by the National Library of Medicine (NLM). The most recent data element definitions are available on the NLM site for <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>studies</a> and <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results</a> data. Data interpretation may depend on:</p>
+    <p class='ptc'>
+      When working with AACT data, it’s important to understand how each data element is defined and collected. For example:
+    </p>
     <ul class='regularDisplay'>
-      <li><b>How the question was phrased.</b> For example, the definition of “Sponsor” does not necessarily imply that the sponsor is the agency paying for the clinical study, as might be expected from the common use of the term.</li>
-      <li><b>Whether the respondent can enter a free-text answer to a specific question, or is restricted to a fixed set of possible responses.</b> Note that the definition of a data element and the available responses may have changed over time. The most recent data element definitions are available at the ClinicalTrials.gov site for <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>study</a> and <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results</a> data. A history of changes through September 2011 for the study definitions can be viewed in the <a target='_blank' href="http://ctti-clinicaltrials.org/files/documents/AACTcomprehensiveDataDictionaryV3_2011.xlsx" download>AACT 2011 Data Dictionary</a>. Monthly copies of the AACT database are bundled with the data element definitions, AACT schema, and AACT data dictionary that were current at the time the copy was created.</li>
-      <li><b>Whether there is dependence between fields.</b> Certain data elements need to be interpreted together with other data elements. For example, data elements such as enrollment date and completion date have a companion data element that indicates whether the value in the first field is an anticipated or actual value.</li>
+      <li><b>Terminology may differ from everyday use.</b> A term like “Sponsor” doesn’t always mean the organization funding the study.</li>
+      <li><b>Data formats vary.</b> Some fields accept free-text answers, while others require choosing from a fixed list of options, which may have changed over time.</li>
+      <li><b>Fields can depend on each other.</b> For instance, a date field may indicate whether it’s an anticipated or actual date.</li>
+      <li><b>Records can be updated at any time.</b> Downloaded data reflects a snapshot in time and doesn’t include a full history of changes.</li>
     </ul>
+    <p class='ptc'>
+      For precise definitions, refer to the National Library of Medicine’s data element documentation or the AACT data dictionary included with each database release.
+    </p>
+  </div>
 
-    <p class="note">Note that the study record may be updated by the owner of the record at any time. Fields such as enrollment type may be changed from anticipated to actual, indicating that the value entered now reflects the actual rather than the planned enrollment. When data are downloaded, the result is a static copy of the database at that particular time point, and the history of changes made to the field is lost.</p>
+  <h2>How complete and accurate are the data?</h2>
+  <p class='ptc'>
+    Data completeness in AACT varies by field and depends on several factors:
+  </p>
 
-    <h2>How complete and accurate are the data?</h2>
+  <ul class='regularDisplay'>
+    <li><b>Regulatory requirements:</b> Fields required by laws like FDAAA are more likely to be filled out.</li>
+    <li><b>Date of study registration:</b> Older studies may lack newer fields added after policy updates.</li>
+    <li><b>Conditional logic:</b> Some fields appear only when certain answers are selected (e.g., biospecimen questions apply only to observational studies).</li>
+    <li><b>Response options:</b> Fields that allow “N/A” are less likely to be missing.</li>
+  </ul>
 
-    <p class='ptc'>The presence of a record in a table indicates that information was submitted to ClinicalTrials.gov for at least one element in that table before the data were downloaded from ClinicalTrials.gov. Some data elements are more/less likely than others to have missing information, depending on several known factors. For example:</p>
+  <p class='ptc'>
+    Even when data is present, accuracy is not guaranteed. ClinicalTrials.gov applies automated and manual checks for completeness and consistency, but submitted data is not independently verified. Errors and outliers (e.g., extremely high enrollment numbers) can occur.
+  </p>
 
-    <ul class='regularDisplay'>
-      <li><b>The data element being required by the FDAAA and/or the ClinicalTrials.gov website.</b> Refer to NLM's <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html' onClick="ga('send','event','external link','guide page: NLM Protocols')">study</a> and <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html' onClick="ga('send','event','external link','guide page: NLM Results')">results</a> data element definitions for specifics regarding these requirements. Requirements may have changed over the history of the ClincalTrials.gov database.</li>
-      <li><b>The date when the data element was introduced.</b> Not all data elements were included in the database at the time of its launch in 2000, but were added later. Studies registered after FDAAA when into effect must meet more requirements than studies registered earlier in the life of ClinicalTrials.gov.</li>
-      <li><b>The branching structure of questions.</b> The availability of certain questions to the person submitting data depends on answers to previous questions. For example, questions about bio-specimen retention are only available for observational studies. Therefore, interventional studies should be excluded when analyzing data elements pertaining to bio-specimens.</li>
-      <li><b>The list of possible answers for data elements with a fixed set of responses.</b> For example, questions that include “N/A” as a possible response are likely to have fewer missing values than questions that do not provide a “N/A” response.</li>
-    </ul>
+  <p class='ptc'>
+    ⚠️ Researchers should examine data distributions, handle missing values transparently, and run consistency checks before analysis. For fewer missing fields, consider limiting analyses to studies registered after September 2007 (when FDAAA requirements began).
+  </p>
 
-    <p class='ptc'>“Missingness” of data may also depend on other unknown factors. Regardless of the cause of missing data, users of ClinicalTrials.gov data sets are encouraged to specify clearly how missing values and “N/A” values are handled in their statistical analysis. For example, are studies with missing values excluded from statistics summarizing that data element, or are they included? In some cases, missing values may be imputed based on other fields (e.g., if a study has a single arm, it cannot employ a randomized design).</p>
-
-    <p class='ptc'>Although the FDAAA and other requirements do not apply to all fields in the database, users might consider including only studies registered post-FDAAA (September 2007), or studies with a primary completion date after December 2007. This will help to limit the number of missing values across many data elements. Users could also consider annotating data elements used in analysis according to whether or not they are FDAAA-required fields, if the user believes this might affect the extent of missing data.</p>
-
-		<p class='ptc'>Even when the data elements for a particular study are complete, users are cautioned to have modest expectations about their accuracy. In particular, results data posted at ClinicalTrials.gov may not be subject to the same level of critical scrutiny as results published in a peer-reviewed journal. As described by <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article" onClick="ga('send','event','external link','guide page: Zarin ref')">Zarin and colleagues in <i>'The ClinicalTrials.gov results database – update and key issues'</i></a>, ClinicalTrials.gov has implemented several measures to ensure data quality. For example, NLM staff apply automated business rules that alert data-providers when required elements are missing or inconsistent. In addition, some manual review is performed by NLM, and a record may be returned to the data-provider if revision is required.  However, ClinicalTrials.gov staff cannot always validate the accuracy of submitted data (e.g., against an independent source).  As Zarin et al. note, “… individual record review has inherent limitations, and posting does not guarantee that the record is fully compliant with either ClinialTrials.gov or legal requirements” <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article" onClick="ga('send','event','external link','guide page: Zarin ref')"><sup>[1]</sup></a></p>
-
-    <p class='ptc'>During our own analysis of the ClinicalTrials.gov database, several extreme values for numeric data elements were encountered, such as an anticipated enrollment of several million subjects. Before proceeding with aggregate analysis, users are encouraged to review data distributions in order to select appropriate analysis methods, and to run their own consistency checks (e.g., to compare whether the number of arm descriptions provided for the study matches the data element that quantifies the number of arms in the study design) as needed.</p>
-
+  <div class="info-box">
     <h2>Use of appropriate statistical inference</h2>
 
     <p class='ptc'>If the AACT results data are to be used to support a meta-analysis or systematic review of the safety or efficacy of a particular intervention, then standard methods of meta-analysis or systematic review (e.g., the <a target='_blank' href="http://annals.org/article.aspx?articleid=744664" onClick="ga('send','event','external link','guide page: PRISMA')">PRISMA statement</a> should be used to appropriately account for study-to-study variability and other sources of uncertainty or bias. We recommend that authors consider the following points when deciding whether to report p-values, confidence intervals, or other probability-based inference when performing aggregate analysis of the ClinicalTrials.gov database:  </p>
+  </div>
 
-    <h2>Is the data-generating mechanism random?</h2>
-    <p class='ptc'>Methods of statistical inference such as p-values and 95% confidence intervals are most appropriate when used to quantify the uncertainty of estimates or comparisons due to a random process that generates the data. Examples of such processes include selection of a random sample of subjects from a broader population, randomly assigning a treatment to a cohort of subjects, or a coin toss about which we aim to predict future results.</p>
+  <h2>Is the data-generating mechanism random?</h2>
+  <p class='ptc'>
+    Methods of statistical inference such as p-values and 95% confidence intervals are most appropriate when used to quantify the uncertainty of estimates or comparisons due to a random process that generates the data. Examples of such processes include selection of a random sample of subjects from a broader population, randomly assigning a treatment to a cohort of subjects, or a coin toss about which we aim to predict future results.
+  </p>
 
-    <p class='ptc'>In the following examples, we recommend against reporting p-values and 95% confidence intervals because the data generating mechanism is not random.</p>
+  <p class='ptc'>
+    In the following examples, we recommend against reporting p-values and 95% confidence intervals because the data-generating mechanism is not random.
+  </p>
 
-    <p class='ptc'><b> Example 1:</b> Descriptive analysis of studies registered in the ClinicalTrials.gov database. In this case, the “sample” equals the “population” (i.e., the group about which we are making conclusions) and there is no role for statistical inference because there is no sample-vs-population uncertainty to be quantified.</p>
+  <ul class='regularDisplay'>
+    <li>
+      <b>Example 1:</b> Descriptive analysis of studies registered in the ClinicalTrials.gov database. In this case, the “sample” equals the “population” (i.e., the group about which we are making conclusions) and there is no role for statistical inference because there is no sample-vs-population uncertainty to be quantified.
+    </li>
+    <li>
+      <b>Example 2:</b> Descriptive analysis of the “clinical trials enterprise” as characterized by the studies registered in ClinicalTrials.gov. Despite mandates for study registration (Table 1), it may be that some studies that are required to be registered are not. In this case, the sample (studies registered in ClinicalTrials.gov) may not equal the population (clinical trials enterprise). However, it is likely that those studies not registered are not excluded at random, and therefore neither p-values nor confidence intervals are helpful to support extrapolation from the sample to the population. To support such extrapolation, we recommend careful consideration of the studies that are highly likely to be registered (see section above on Population), and to limit inference to this population so that sample-vs-population uncertainty is minimal.
+    </li>
+  </ul>
 
-    <p class='ptc'><b>Example 2: </b>Descriptive analysis of the “clinical trials enterprise” as characterized by the studies registered in ClinicalTrials.gov. Despite mandates for study registration <a href="#table1">(Table 1)</a>, it may be that some studies that are required to be registered are not. In this case the sample (studies registered in ClinicalTrials.gov) may not equal the population (clinical trials enterprise). However, it is likely that those studies not registered are not excluded at random, and therefore neither p-values nor confidence intervals are helpful to support extrapolation from the sample to the population. To support such extrapolation, we recommend careful consideration of the studies that are highly likely to be registered (see section above on Population), and to limit inference to this population so that sample-vs-population uncertainty is minimal.</p>
+  <h2>How can I objectively identify important differences?</h2>
 
-    <h2>How can I objectively identify important differences?</h2>
+  <p class='ptc'>In practice, p-values and confidence intervals are often employed even when there is no random data generating process to highlight differences that are larger than “noise” (e.g., authors may want to highlight differences with a p-value < .001).  While this practice may not have a strong foundation in statistical philosophy, we acknowledge that many audiences (e.g., journal peer reviewers) may demand p-values because they appear to provide objective criteria for identifying larger-than-expected signals in the data.  While we don’t encourage reporting of p-values for this purpose, we do encourage analysts to specify objective criteria for evaluating signals in the data.  Examples are provided:</p>
 
-    <p class='ptc'>In practice, p-values and confidence intervals are often employed even when there is no random data generating process to highlight differences that are larger than “noise” (e.g., authors may want to highlight differences with a p-value < .001).  While this practice may not have a strong foundation in statistical philosophy, we acknowledge that many audiences (e.g., journal peer reviewers) may demand p-values because they appear to provide objective criteria for identifying larger-than-expected signals in the data.  While we don’t encourage reporting of p-values for this purpose, we do encourage analysts to specify objective criteria for evaluating signals in the data.  Examples are provided:</p>
+  <p class='ptc'>a) Prior to examining the data, specify comparisons of major interest, or quantities to be estimated. </p>
 
-    <p class='ptc'>a) Prior to examining the data, specify comparisons of major interest, or quantities to be estimated. </p>
+  <p class='ptc'>b) Determine the magnitude of differences that would have practical significance.  (e.g., a 25% difference in source of funding between studies of 2 pediatric <i>Conditions</i>, or a difference in enrollment of 100 participants).  </p>
 
-    <p class='ptc'>b) Determine the magnitude of differences that would have practical significance.  (e.g., a 25% difference in source of funding between studies of 2 pediatric <i>Conditions</i>, or a difference in enrollment of 100 participants).  </p>
+  <p class='ptc'>c) Determine appropriate formulas for quantifying differences between groups or summarizing population variability.  This quantification could take into account of the observed difference, variability in the data, and the number of observations.  Examples are provided:</p>
 
-    <p class='ptc'>c) Determine appropriate formulas for quantifying differences between groups or summarizing population variability.  This quantification could take into account of the observed difference, variability in the data, and the number of observations.  Examples are provided:</p>
+  <ul class='regularDisplay'>
+    <li>When summarizing a continuous characteristic such as enrollment, the analyst might choose to report the median and 5th to 95th percentiles.</li>
+    <li>To quantify signal to noise, the analyst could calculate a t-statistic or a chi-squared statistic (without the p-value) and rank differences between 2 groups based on these values.  The analyst might pre-specify a threshold (e.g., absolute value of 3) to flag notable differences.</li>
+  </ul>
 
-    <ul class='regularDisplay'>
-      <li>When summarizing a continuous characteristic such as enrollment, the analyst might choose to report the median and 5th to 95th percentiles.</li>
-      <li>To quantify signal to noise, the analyst could calculate a t-statistic or a chi-squared statistic (without the p-value) and rank differences between 2 groups based on these values.  The analyst might pre-specify a threshold (e.g., absolute value of 3) to flag notable differences.</li>
-    </ul>
+  <h2>Specific tips for working with the AACT database</h2>
 
-    <h2>Specific tips for working with the AACT database</h2>
+  <ul class='regularDisplay'>
+    <li>Users are encouraged to use the <a href='/schema' target="_blank" onClick="ga('send','event','download','guide page: download schema')">Schema Diagram</a> to determine relationships between different AACT tables. These relationships determine how tables may be linked using tools such as SAS, R & SQL.</li>
+    <li>The <i>nct_id</i> uniquely identifies each study; it serves as the primary key in the <i>Studies</i> table. Each record in the <i>Studies</i> table has a unique <i>nct_id</i> value. <i>nct_id</i> also appears in every table related to <i>Studies</i> so that every record in every table can link back to the study to which it refers.</li>
+    <li>Every table other than <i>Studies</i> has a primary key named <i>id</i>, which provides an integer that uniquely identifies each row in that table. (The <i>Studies</i> table uses <i>nct_id</i> instead of <i>id</i> as the unique identifier for each row.)</li>
+    <li>To link table information to the study to which it refers, you simply match on <i>nct_id</i>. For example, every record in the <i><i>Conditions</i></i> table with an NCT_ID of ‘NCT0000001’ refers to the study with the NCT_ID: ‘NCT0000001’ (saved in <i>Studies.nct_id</i>). The <i>Conditions</i> table may contain multiple records with an NCT_ID of ‘NCT0000001’ which means this study was defined in ClinicalTrials.gov as being associated with the <i>Conditions</i> listed in <i>Conditions</i> with that NCT_ID.</li>
+    <li>Information in several tables are also related to information in other tables. In this case, the table that belongs to another table will include a foreign key that identifies the record to which it belongs. Foreign keys are always named according to a simple rule: the singular name of the related table followed by: ‘_id’.  For example, <i>Facility_Contacts</i> includes a data element: <i>facility_id</i> which is the foreign key to <i>Facilities.id</i></li>
+    <li>Each record’s foreign_key (ie. <i>facility_id</i>) contains the value of the unique identifier (id) of the record in the other table to which it belongs. For example, a facility may have multiple contacts. To find the contacts for a particular facility, look for the records in <i>Facility_Contacts</i> where the value in <i>facility_id</i> is same as the value in id for that facility in <i>Facilities</i>. In short, tables are related to each other with this pattern: <i>child.&lt;parent_name&gt;_id = parent.id</i> </li>
+    <li>Note that the ID assigned to a particular record (e.g., to a record in the <i>Facilities</i> table) is merely the method used to identify unique records in the database table, and to facilitate linking of records between database tables. The ID does not identify unique facilities in the real world. For example, if studies A and B are both enrolling patients at Duke University Medical Center, there will be one instance of Duke University Medical Center for each study, and these records will have different ID values, even though they may be the same physical research site.</li>
+  </ul>
 
-    <ul class='regularDisplay'>
-      <li>Users are encouraged to use the <a href='/schema' target="_blank" onClick="ga('send','event','download','guide page: download schema')">Schema Diagram</a> to determine relationships between different AACT tables. These relationships determine how tables may be linked using tools such as SAS, R & SQL.</li>
-      <li>The <i>nct_id</i> uniquely identifies each study; it serves as the primary key in the <i>Studies</i> table. Each record in the <i>Studies</i> table has a unique <i>nct_id</i> value. <i>nct_id</i> also appears in every table related to <i>Studies</i> so that every record in every table can link back to the study to which it refers.</li>
-      <li>Every table other than <i>Studies</i> has a primary key named <i>id</i>, which provides an integer that uniquely identifies each row in that table. (The <i>Studies</i> table uses <i>nct_id</i> instead of <i>id</i> as the unique identifier for each row.)</li>
-      <li>To link table information to the study to which it refers, you simply match on <i>nct_id</i>. For example, every record in the <i><i>Conditions</i></i> table with an NCT_ID of ‘NCT0000001’ refers to the study with the NCT_ID: ‘NCT0000001’ (saved in <i>Studies.nct_id</i>). The <i>Conditions</i> table may contain multiple records with an NCT_ID of ‘NCT0000001’ which means this study was defined in ClinicalTrials.gov as being associated with the <i>Conditions</i> listed in <i>Conditions</i> with that NCT_ID.</li>
-      <li>Information in several tables are also related to information in other tables. In this case, the table that belongs to another table will include a foreign key that identifies the record to which it belongs. Foreign keys are always named according to a simple rule: the singular name of the related table followed by: ‘_id’.  For example, <i>Facility_Contacts</i> includes a data element: <i>facility_id</i> which is the foreign key to <i>Facilities.id</i></li>
-      <li>Each record’s foreign_key (ie. <i>facility_id</i>) contains the value of the unique identifier (id) of the record in the other table to which it belongs. For example, a facility may have multiple contacts. To find the contacts for a particular facility, look for the records in <i>Facility_Contacts</i> where the value in <i>facility_id</i> is same as the value in id for that facility in <i>Facilities</i>. In short, tables are related to each other with this pattern: <i>child.&lt;parent_name&gt;_id = parent.id</i> </li>
-      <li>Note that the ID assigned to a particular record (e.g., to a record in the <i>Facilities</i> table) is merely the method used to identify unique records in the database table, and to facilitate linking of records between database tables. The ID does not identify unique facilities in the real world. For example, if studies A and B are both enrolling patients at Duke University Medical Center, there will be one instance of Duke University Medical Center for each study, and these records will have different ID values, even though they may be the same physical research site.</li>
-    </ul>
-
-    <p class='ptc'><%= render partial: 'schema_info' %></p>
+  <p class='ptc'><%= render partial: 'schema_info' %></p>
 
 
-    <h2>References</h2>
+  <h2>References</h2>
 
-    <ol>
-      <li>Zarin, D. A., Tse, T. T., Williams, R. J., Califf, R. M., and Ide, N. C. (2011). <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article" onClick="ga('send','event','external link','guide page: Zarin 1 ref')">The ClinicalTrials.gov results database – update and key issues</a>. N Engl J Med 364: 852–60.</li>
-      <li><a target='_blank' href="http://www.fda.gov/RegulatoryInformation/Legislation/SignificantAmendmentstotheFDCAct/FoodandDrugAdministrationAmendmentsActof2007/default.htm"  onClick="ga('send','event','external link','guide page: FDA ref')" >Food and Drug Administration Amendments Act of 2007</a>. Public Law 110-95.</li>
-      <li>Laine, C., Horton R., DeAngelis C.D., et al. <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMe078110#t=article"  onClick="ga('send','event','external link','guide page: Laine ref')">Clinical trial registration – looking back and moving ahead</a>. N Engl J Med 356: 2734–6.</li>
-      <li><a target='_blank' href="http://ec.europa.eu/health/files/eudralex/vol-10/2008_07/c_16820080703en00030004_en.pdf" onClick="ga('send','event','external link','guide page: European Commission ref')" >Communication from the Commission regarding the guideline on the data fields contained in the clinical trials database provided for in Article 11 of Directive 2001/20/EC to be included in the database on medicinal products provided for in Article 57 or Regulation (EC) No 726/2004</a>. In: European Commission, ed. Official Journal of the European Union, 2008. (2008/C 168/02.)</li>
-      <li><a target='_blank' href="http://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000044.jsp"  onClick="ga('send','event','external link','guide page: EudraCT ref')">Guidance on the information concerning paediatric clinical trials to be entered into the EU Database on Clinical Trials (EudraCT) and on the information to be made public by the European Medicines Agency (EMEA), in accordance with Article 41 of Regulation (EC) No 1901/2006</a>. In: European Commission, ed. Official Journal of the European Union, 2009. (2009/C 28/01.)</li>
-      <li>Zarin, D. A., Ide, N. C., Tse, T. et al. (2007). <a target='_blank' href="http://www.ncbi.nlm.nih.gov/pubmed/17507347"  onClick="ga('send','event','external link','guide page: Zarin2 ref')">Issues in the registration of clinical trials</a>. JAMA 297: 2112—2120.</li>
-      <li>Moher, D., Liberati, A., Tetzlaff, J. and Altman, D. G. (for the PRISMA Group)(2009). <a target='_blank' href="http://annals.org/article.aspx?articleid=744664"  onClick="ga('send','event','external link','guide page: Moher ref')">Preferred reporting items for systematic reviews and meta-analyses: the PRISMA statement</a>, BMJ 339: 332—336.</li>
-      <li>Tse, T., Williams, R. J., Zarin, D. A. (2009). <a target='_blank' href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/"  onClick="ga('send','event','external link','guide page: Tse ref')">Reporting “basic results” in ClinicalTrials.gov</a>. CHEST 136: 295—303.</li>
-    </ol>
+  <ol>
+    <li>Zarin, D. A., Tse, T. T., Williams, R. J., Califf, R. M., and Ide, N. C. (2011). <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article" onClick="ga('send','event','external link','guide page: Zarin 1 ref')">The ClinicalTrials.gov results database – update and key issues</a>. N Engl J Med 364: 852–60.</li>
+    <li><a target='_blank' href="http://www.fda.gov/RegulatoryInformation/Legislation/SignificantAmendmentstotheFDCAct/FoodandDrugAdministrationAmendmentsActof2007/default.htm"  onClick="ga('send','event','external link','guide page: FDA ref')" >Food and Drug Administration Amendments Act of 2007</a>. Public Law 110-95.</li>
+    <li>Laine, C., Horton R., DeAngelis C.D., et al. <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMe078110#t=article"  onClick="ga('send','event','external link','guide page: Laine ref')">Clinical trial registration – looking back and moving ahead</a>. N Engl J Med 356: 2734–6.</li>
+    <li><a target='_blank' href="http://ec.europa.eu/health/files/eudralex/vol-10/2008_07/c_16820080703en00030004_en.pdf" onClick="ga('send','event','external link','guide page: European Commission ref')" >Communication from the Commission regarding the guideline on the data fields contained in the clinical trials database provided for in Article 11 of Directive 2001/20/EC to be included in the database on medicinal products provided for in Article 57 or Regulation (EC) No 726/2004</a>. In: European Commission, ed. Official Journal of the European Union, 2008. (2008/C 168/02.)</li>
+    <li><a target='_blank' href="http://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000044.jsp"  onClick="ga('send','event','external link','guide page: EudraCT ref')">Guidance on the information concerning paediatric clinical trials to be entered into the EU Database on Clinical Trials (EudraCT) and on the information to be made public by the European Medicines Agency (EMEA), in accordance with Article 41 of Regulation (EC) No 1901/2006</a>. In: European Commission, ed. Official Journal of the European Union, 2009. (2009/C 28/01.)</li>
+    <li>Zarin, D. A., Ide, N. C., Tse, T. et al. (2007). <a target='_blank' href="http://www.ncbi.nlm.nih.gov/pubmed/17507347"  onClick="ga('send','event','external link','guide page: Zarin2 ref')">Issues in the registration of clinical trials</a>. JAMA 297: 2112—2120.</li>
+    <li>Moher, D., Liberati, A., Tetzlaff, J. and Altman, D. G. (for the PRISMA Group)(2009). <a target='_blank' href="http://annals.org/article.aspx?articleid=744664"  onClick="ga('send','event','external link','guide page: Moher ref')">Preferred reporting items for systematic reviews and meta-analyses: the PRISMA statement</a>, BMJ 339: 332—336.</li>
+    <li>Tse, T., Williams, R. J., Zarin, D. A. (2009). <a target='_blank' href="http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/"  onClick="ga('send','event','external link','guide page: Tse ref')">Reporting “basic results” in ClinicalTrials.gov</a>. CHEST 136: 295—303.</li>
+  </ol>
 
 </section>

--- a/app/views/pages/points_to_consider.html.erb
+++ b/app/views/pages/points_to_consider.html.erb
@@ -191,7 +191,7 @@
 
 
   <h2>Is the information in AACT up-to-date?</h2>
-  <div class="info-box">
+  <div class="gray-box">
     <p class='ptc'>
       The AACT database updates every night at midnight, making it typically one day behind ClinicalTrials.gov.
     </p>

--- a/app/views/pages/points_to_consider.html.erb
+++ b/app/views/pages/points_to_consider.html.erb
@@ -7,200 +7,373 @@
 
   <div class="info-box">
     <p class='ptc'>
-      AACT (Aggregate Analysis of 
-      <a target='_blank' href="https://clinicaltrials.gov" onClick="ga('send','event','external link','guide page: clinicaltrials.gov')">
-        ClinicalTrials.gov
-      </a>) is a publicly available PostgreSQL database maintained by the Clinical Trials Transformation Initiative (CTTI). It contains a structured version of all study records from ClinicalTrials.gov.
+      The Aggregate Analysis of ClinicalTrials.gov (AACT) is a PostgreSQL relational database that contains detailed information from clinical studies registered on ClinicalTrials.gov.
+
+      AACT includes all publicly available protocol and results data elements from ClinicalTrials.gov. Data are downloaded daily and loaded into the AACT database to ensure it stays current.
     </p>
-
-    <dl class='ptc'>
-      <dt><b>Updated Daily:</b></dt>
-      <dd>New and changed study records are added nightly based on the ClinicalTrials.gov RSS feed and API.</dd>
-
-      <dt><b>Full Monthly Refresh:</b></dt>
-      <dd>The entire database is rebuilt once a month to capture deletions and ensure completeness.</dd>
-
-      <dt><b>Structured Format:</b></dt>
-      <dd>AACT transforms XML records into a relational database with organized tables and fields.</dd>
-
-      <dt><b>Open Access:</b></dt>
-      <dd>Anyone can query the data using SQL or download full database dumps.</dd>
-    </dl>
   </div>
 
   <h2>What population of studies is represented in AACT?</h2>
+  <p class='ptc'>
+    AACT includes all studies that are registered and publicly available on ClinicalTrials.gov. The registry has accepted studies since <b>February 29, 2000</b>, covering both interventional and observational research.
+  </p>
 
-  <div class="info-box">
-    <p class='ptc'>
-      AACT includes all publicly available study records from ClinicalTrials.gov, across various types:
-    </p>
+  <p class='ptc'>
+    ClinicalTrials.gov includes:
+  </p>
 
-    <ul class='regularDisplay'>
-      <li>Interventional trials (e.g., drug/device studies)</li>
-      <li>Observational studies</li>
-      <li>Expanded access programs</li>
-    </ul>
+  <ul class='regularDisplay'>
+    <li><b>Interventional studies</b>, where participants are assigned to specific interventions under a research protocol.</li>
+    <li><b>Observational studies</b> that monitor outcomes without assigned interventions.</li>
+    <li><b>Expanded Access records</b>, describing how patients can obtain experimental drugs or devices when standard treatments are unavailable, and they cannot participate in clinical trials.</li>
+  </ul>
 
-    <p class='ptc'>
-      Several global policies drive study registration and results reporting. These include:
-    </p>
+  <p class='ptc'>
+    Registration and results reporting have become increasingly mandatory due to legal, institutional, and publication requirements. Key drivers include the Food and Drug Administration Amendments Act (FDAAA), the International Committee of Medical Journal Editors 
+    (<a target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/' onClick="ga('send','event','external link','guide page: ICMJE')">ICMJE</a>), the European Medicines Agency (EMA), and the National Institutes of Health (NIH). These policies define which studies must register and report results in ClinicalTrials.gov.
+  </p>
 
-    <ul class='regularDisplay'>
-      <li><b>FDAAA 801 (2007) & Final Rule (2017)</b> — U.S. laws requiring certain trials to register and report results.</li>
-      <li><b>NIH Policy (2016)</b> — Extends reporting expectations to all NIH-funded studies.</li>
-      <li><b>ICMJE Policy</b> — Requires trial registration for publication eligibility in participating journals.</li>
-      <li><b>EMA (2014) and NCI Requirements</b> — Encourage transparency in clinical research.</li>
-    </ul>
-  </div>
+  <p class='ptc'>
+    See the table below for an overview of major reporting requirements:
+  </p>
+
+  <h4>Table 1: Scope of Interventional Studies Covered by Major Reporting Policies*</h4>
+
+  <table id='pointsToConsider' class='regularDisplay'>
+    <thead>
+      <tr>
+        <th>Policy</th>
+        <th>Registration & Results Reporting Requirements</th>
+        <th>Effective Date(s)</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class='even'>
+        <td>
+          <p class='ptc'>
+            <a target='_blank' href='https://www.federalregister.gov/documents/2016/09/21/2016-22379/nih-policy-on-the-dissemination-of-nih-funded-clinical-trial-information' onClick="ga('send','event','external link','guide page: NIH Policy')">NIH Policy</a>
+          </p>
+        </td>
+        <td>
+          <p class='ptc'>
+            All clinical trials funded wholly or partly by NIH must be registered on ClinicalTrials.gov and report summary results, whether or not subject to FDAAA 801.
+          </p>
+        </td>
+        <td>
+          <p class='ptc'>
+            <b>January 18, 2017.</b> Applies to funding applications submitted on or after this date. For the NIH intramural program, applies to trials initiated on or after January 18, 2017. Timelines align with FDAAA 801.
+          </p>
+        </td>
+      </tr>
+
+      <tr class='odd'>
+        <td>
+          <a target='_blank' href='https://grants.nih.gov/grants/guide/notice-files/NOT-CA-15-011.html' onClick="ga('send','event','external link','guide page: NCI Access Policy')">NCI Access Policy</a>
+        </td>
+        <td>
+          <p class='ptc'>
+            Requires public reporting of final trial results for all NCI-supported interventional trials (extramural or intramural) within 12 months of the primary completion date, even if the trial was terminated early. Incorporated as a term of the award.
+          </p>
+        </td>
+        <td>
+          <p class='ptc'><b>January, 2015</b></p>
+        </td>
+      </tr>
+
+      <tr class='even'>
+        <td>
+          <a target='_blank' href='http://www.fda.gov/RegulatoryInformation/Legislation/SignificantAmendmentstotheFDCAct/FoodandDrugAdministrationAmendmentsActof2007/default.htm' onClick="ga('send','event','external link','guide page: FDAAA')">FDAAA and Final Rule</a>
+        </td>
+        <td>
+          <p class='ptc'>
+            Registration is required for:
+          </p>
+          <ul class='regularDisplay'>
+            <li>Interventional studies of drugs, biologics, or devices (approved or unapproved)</li>
+            <li>Phases 2 through 4</li>
+            <li>Studies with at least one US site or conducted under IND/IDE</li>
+          </ul>
+          <p class='ptc'>
+            Results reporting is required for studies involving approved, licensed, or cleared products. The 
+            <a target='_blank' href='http://www.nejm.org/doi/full/10.1056/NEJMsr1611785' onClick="ga('send','event','external link','guide page: Final Rules')">Final Rule</a>
+            expanded requirements to some unapproved products.
+          </p>
+        </td>
+        <td>
+          <p class='ptc'>
+            <b>September 27, 2007.</b> Applies to studies initiated after this date or completed after December 25, 2007. Registration required within 21 days of first patient enrollment. Results due within one year after primary outcome data collection.
+            <br><br>
+            For device studies not yet approved, public posting may be delayed until after FDA approval.
+            <br><br>
+            <b>September, 2008.</b> Results reporting launched with optional adverse event reporting.
+            <br><br>
+            <b>September, 2009.</b> Adverse event reporting became mandatory.
+            <br><br>
+            <b>January 18, 2017.</b> Final Rule for FDAAA 801 effective; compliance expected from April 18, 2017.
+            <br><br>
+            <ul class='regularDisplay'>
+              <li>Responsible parties for device trials may authorize NIH to post registration data before FDA clearance.</li>
+              <li>Results reporting for unapproved products may be delayed up to 3 years after the primary completion date.</li>
+            </ul>
+          </p>
+        </td>
+      </tr>
+
+      <tr class='odd'>
+        <td>
+          <a target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/' onClick="ga('send','event','external link','guide page: ICMJE')">ICMJE</a>
+        </td>
+        <td>
+          <p class='ptc'>
+            All interventional studies must be registered in ClinicalTrials.gov or another recognized registry to be eligible for publication. No results reporting is mandated.
+          </p>
+        </td>
+        <td>
+          <p class='ptc'>
+            <b>July 1, 2005.</b> Applies to studies initiated after this date; earlier studies must be retrospectively registered for publication eligibility.
+          </p>
+        </td>
+      </tr>
+
+      <tr class='even'>
+        <td>
+          <a target='_blank' href='https://www.ema.europa.eu/ema/index.jsp?curl=pages/regulation/general/general_content_000629.jsp&mid=WC0b01ac05808768df' onClick="ga('send','event','external link','guide page: EMA')">EMA</a>
+        </td>
+        <td>
+          <p class='ptc'>
+            Registration required for:
+          </p>
+          <ul class='regularDisplay'>
+            <li>Interventional studies of drugs or biologics</li>
+            <li>Pediatric phase 1 studies</li>
+            <li>Phases 2 through 4</li>
+            <li>Studies with at least one EU site</li>
+          </ul>
+          <p class='ptc'>
+            Results reporting is required for all registered studies.
+          </p>
+        </td>
+        <td>
+          <p class='ptc'>
+            <b>May 1, 2004.</b> EMA launched 
+            <a target='_blank' href='https://eudract.ema.europa.eu/' onClick="ga('send','event','external link','guide page: EudraCT')">EudraCT</a>.<br><br>
+            <b>March 22, 2011.</b> EMA launched the 
+            <a target='_blank' href='https://www.clinicaltrialsregister.eu/' onClick="ga('send','event','external link','guide page: EU Clinical Trials Register')">EU Clinical Trials Register</a>.<br><br>
+            <b>October 11, 2013.</b> EMA expanded EudraCT to include summary results.
+          </p>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class='ptcFootNote'>
+    * Adapted from 
+    <a class='ptcFootNote' target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article">The ClinicalTrials.gov results database – update and key issues</a> and 
+    <a class='ptcFootNote' target='_blank' href='https://clinicaltrials.gov/ct2/about-site/history'>ClinicalTrials.gov summary of selected events, policies, and laws related to the development and expansion of ClinicalTrials.gov</a>. For complete descriptions of policy requirements, see the references cited. EMA = European Medicines Agency; EU = European Union; FDAAA = Food and Drug Administration Amendments Act; ICMJE = International Committee of Medical Journal Editors; IDE = investigational device exemption; IND = investigational new drug application; NCI = National Cancer Institute; NIH = National Institutes of Health; US = United States.
+  </p>
+
+  <p class='ptc'>
+    Based on these policies, the following factors influence the likelihood that a study is registered in ClinicalTrials.gov (and therefore included in AACT):
+  </p>
+
+  <ul class='regularDisplay'>
+    <li>Interventional studies are more likely to be registered than observational studies.</li>
+    <li>Studies begun before the <a target='_blank' href='http://www.icmje.org/about-icmje/faqs/clinical-trials-registration/'>ICMJE</a> requirement in <b>July, 2005</b> are less likely to be registered, especially if results remain unpublished (e.g., negative results).</li>
+    <li>Studies involving drugs, biologics, or devices are more likely to be registered than those involving other types of interventions.</li>
+    <li>Studies with at least one site in the United States or European Union are more likely to be registered.</li>
+    <li>Studies involving a drug or device manufactured in the United States are more likely to be registered.</li>
+    <li>Studies subject to an IND or IDE are more likely to be registered, especially if intended to support US marketing approval.</li>
+    <li>Phase 1 adult drug studies and small feasibility studies of devices are less likely to be registered.</li>
+    <li>Pediatric studies may be more likely to be registered.</li>
+    <li>NIH-funded studies are generally registered, regardless of intervention type or phase.</li>
+    <li>FDA-regulated device studies are usually registered, though records for unapproved devices may remain unpublished until after approval.</li>
+  </ul>
+
 
   <h2>Is the information in AACT up-to-date?</h2>
-
   <div class="info-box">
-    <h4>Nightly Updates</h4>
     <p class='ptc'>
-      Every night around midnight (U.S. Eastern Time), new or modified study records from ClinicalTrials.gov are imported into a background version of AACT. After validation, the updated database is copied to the public AACT database, usually within 90 minutes.
-    </p>
-    <p class='ptc'>
-      During this brief copy process (typically 5 minutes), AACT is unavailable.
+      The AACT database updates every night at midnight, making it typically one day behind ClinicalTrials.gov.
     </p>
 
-    <h4>Monthly Refresh</h4>
     <p class='ptc'>
-      Once a month, AACT is completely rebuilt from scratch using the entire ClinicalTrials.gov dataset. This ensures:
+      Each night:
     </p>
+
     <ul class='regularDisplay'>
-      <li>Deleted studies (those removed from ClinicalTrials.gov) are reflected.</li>
-      <li>Data integrity is maintained across all tables and fields.</li>
+      <li>The ClinicalTrials.gov RSS feed identifies studies added or changed the previous day.</li>
+      <li>The ClinicalTrials.gov API retrieves data for only those new or updated studies.</li>
+      <li>Only new or modified studies are inserted or updated in AACT.</li>
     </ul>
+
+    <p class='ptc'>
+      This nightly process takes about 1.5 hours, depending on the number of changes.
+    </p>
+
+    <p class='ptc'>
+      Occasionally, studies are removed from ClinicalTrials.gov (for example, duplicate records). Because nightly updates don’t detect removals, AACT is completely refreshed once per month to stay in sync.
+    </p>
+
+    <p class='ptc'>
+      Both nightly (incremental) and monthly (full) updates run on a background copy of the database so the public version remains available during processing. After updates complete, the refreshed database replaces the public version in a copy step that takes about 5 minutes. Because nightly updates begin at midnight, this brief downtime usually occurs between 1:00 am and 2:00 am.
+    </p>
+
+    <p class='ptc'>
+      Please refer to the posted <a target='_blank' href='/update_policy'>update schedule</a> for more details.
+    </p>
   </div>
 
   <h2>How are unique studies identified in AACT?</h2>
+  <p class='ptc'>
+    Each study registered in ClinicalTrials.gov has a unique identifier called the <code>NCT_ID</code>.
+  </p>
 
   <p class='ptc'>
-    Studies registered at ClinicalTrials.gov are identified by a unique identifier, the NCT_ID.  
-    Because of the quality assurance measures applied by ClinicalTrials.gov staff on registration entries, 
-    we can be reasonably certain that each study (i.e., NCT_ID) entered in ClinicalTrials.gov refers to a unique clinical study, 
-    however a small number of 
-    <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>
-      duplicate records may exist in the database.
-    </a>
+    Because ClinicalTrials.gov applies quality assurance checks during registration, each <code>NCT_ID</code> generally represents a distinct clinical study. However, a small number of 
+    <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pubmed/17507347'>duplicate records may exist in the database</a>.
   </p>
 
   <h2>How does content in AACT compare to what is in ClinicalTrials.gov?</h2>
 
   <div class="info-box">
     <p class='ptc'>
-      AACT contains the same publicly available study data as ClinicalTrials.gov but stores it in a structured, relational database format.
+      AACT contains all protocol and results data for every study publicly available on ClinicalTrials.gov. It includes the full current record for each study exactly as it appears in ClinicalTrials.gov.
     </p>
+
     <p class='ptc'>
-      It reflects only the most current version of each study record and does not preserve historical edits. While the core content remains unchanged, AACT includes some derived fields (like those in the calculated_values table) to make querying and analysis easier.
+      The database preserves the original XML content downloaded via the ClinicalTrials.gov API without cleaning or manipulation. However, to aid queries, AACT also includes derived variables in the <code>Calculated_Values</code> table.
+    </p>
+
+    <p class='ptc'>
+      Note that the history of changes to study records (available on the ClinicalTrials.gov archive site) is not included in AACT.
     </p>
   </div>
 
 
   <h2>What types of questions can be investigated using ClinicalTrials.gov data?</h2>
+  <p class='ptc'>
+    The AACT database includes both study protocol and results data elements.
+    Protocol records describe study details such as sponsor, disease condition, intervention type, participant eligibility, enrollment targets, study design, locations, and outcome measures.
+    Summary results cover participant flow, baseline characteristics, outcomes, and frequencies of serious and other adverse events.
+    The <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/'>article by Tse et al.</a> provides a helpful overview of the basic results reported at ClinicalTrials.gov.
+  </p>
 
-  <p class='ptc'>The AACT database contains both ‘study protocol’ and ‘results data’ elements. The protocol (or registration) records describe the study characteristics including sponsor, disease condition, type of intervention, participant eligibility, anticipated enrollment, study design, locations, and outcome measures. Summary results data elements including participant flow, baseline characteristics, outcome results, and frequencies of serious and other adverse events are included in AACT.  The <a target='_blank' href='http://www.ncbi.nlm.nih.gov/pmc/articles/PMC2821287/'>article by Tse et al</a> may be helpful in understanding the components of the basic results that are reported at ClinicalTrials.gov.</p>
-
+  <h2>How can protocol/registration data be used?</h2>
   <div class="info-box">
-    <h2>How can protocol/registration data be used?</h2>
-
-    <p class='ptc'>Researchers can use protocol data from AACT to explore and compare the characteristics of different groups of clinical studies. For example, you might examine typical enrollment sizes for phase 3 breast cancer trials or analyze differences between studies based on sponsor type, intervention (e.g., drug vs. device), or purpose (e.g., prevention vs. treatment).</p>
+    <p class='ptc'>
+      Investigators can use the database to explore characteristics of specific clinical study subsets (e.g., typical enrollment in phase 3 breast cancer studies) and to compare these characteristics across subgroups (e.g., sponsor type, device versus drug interventions, or prevention versus treatment).
+    </p>
   </div>
 
   <h2>How can results and adverse events data be used?</h2>
+  <p class='ptc'>
+    Researchers can use results and adverse events data from ClinicalTrials.gov for meta-analyses or systematic reviews—for example, comparing the efficacy and safety of diabetes therapies.  
+    However, since only a subset of registered studies are required to report results, ClinicalTrials.gov data is best used as a supplement to traditional sources like published and unpublished manuscripts.
+    Standard guidelines such as the <a target='_blank' href="http://annals.org/article.aspx?articleid=744664">PRISMA statement</a> should guide how to identify and combine summary data from ClinicalTrials.gov and the literature.
+  </p>
 
-  <p class='ptc'>Researchers can use results and adverse events data from AACT to support meta-analyses or systematic reviews—for example, comparing the safety and effectiveness of different diabetes treatments. However, because only a subset of studies on ClinicalTrials.gov are required to report results, this data often serves as a supplement rather than a primary source. When using these data for research, it’s important to follow standard guidelines for systematic reviews, such as the PRISMA statement.</p>
-
-  <div class="info-box">
-    <h2>How should data elements be interpreted?</h2>
+  <h2>How should data elements be interpreted?</h2>
+  <div class="info-box">  
     <p class='ptc'>
-      When working with AACT data, it’s important to understand how each data element is defined and collected. For example:
+      When interpreting AACT data, refer to the authoritative definitions from the National Library of Medicine (NLM). The latest data element definitions are available on the NLM site for 
+      <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>studies</a> and 
+      <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results</a> data. Interpretation depends on:
     </p>
+
     <ul class='regularDisplay'>
-      <li><b>Terminology may differ from everyday use.</b> A term like “Sponsor” doesn’t always mean the organization funding the study.</li>
-      <li><b>Data formats vary.</b> Some fields accept free-text answers, while others require choosing from a fixed list of options, which may have changed over time.</li>
-      <li><b>Fields can depend on each other.</b> For instance, a date field may indicate whether it’s an anticipated or actual date.</li>
-      <li><b>Records can be updated at any time.</b> Downloaded data reflects a snapshot in time and doesn’t include a full history of changes.</li>
+      <li><b>How the question was phrased.</b> For example, “Sponsor” may not always mean the funding agency, differing from common usage.</li>
+      <li><b>Whether responses are free-text or from fixed options.</b> Definitions and allowed responses may change over time. See the <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>latest study definitions</a>, <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results definitions</a>, and the <a target='_blank' href="http://ctti-clinicaltrials.org/files/documents/AACTcomprehensiveDataDictionaryV3_2011.xlsx" download>AACT 2011 Data Dictionary</a> for history. Monthly AACT releases include corresponding dictionaries and schema.</li>
+      <li><b>Dependence between fields.</b> Some elements must be interpreted with related data—for example, enrollment and completion dates have companion fields indicating whether the value is anticipated or actual.</li>
     </ul>
-    <p class='ptc'>
-      For precise definitions, refer to the National Library of Medicine’s data element documentation or the AACT data dictionary included with each database release.
+
+    <p class='note'>
+      Note that study records can be updated by owners at any time. For example, enrollment type may change from anticipated to actual. Downloaded data reflects a static snapshot; history of changes is not preserved.
     </p>
   </div>
 
   <h2>How complete and accurate are the data?</h2>
   <p class='ptc'>
-    Data completeness in AACT varies by field and depends on several factors:
+    A record in a table means at least one element in that table was submitted to ClinicalTrials.gov before data download. Some elements are more likely to be missing than others, influenced by factors such as:
   </p>
 
   <ul class='regularDisplay'>
-    <li><b>Regulatory requirements:</b> Fields required by laws like FDAAA are more likely to be filled out.</li>
-    <li><b>Date of study registration:</b> Older studies may lack newer fields added after policy updates.</li>
-    <li><b>Conditional logic:</b> Some fields appear only when certain answers are selected (e.g., biospecimen questions apply only to observational studies).</li>
-    <li><b>Response options:</b> Fields that allow “N/A” are less likely to be missing.</li>
+    <li><b>FDAAA and ClinicalTrials.gov requirements.</b> See NLM’s <a target='_blank' href='https://prsinfo.clinicaltrials.gov/definitions.html'>study</a> and <a target='_blank' href='https://prsinfo.clinicaltrials.gov/results_definitions.html'>results</a> data definitions for details. Requirements have evolved over time.</li>
+    <li><b>Date of element introduction.</b> Not all data elements existed at ClinicalTrials.gov launch in 2000; later studies must meet more requirements.</li>
+    <li><b>Question branching.</b> Some questions depend on prior answers—for example, bio-specimen questions apply only to observational studies, so interventional studies should be excluded when analyzing those data.</li>
+    <li><b>Answer options.</b> Data elements offering “N/A” responses often have fewer missing values.</li>
   </ul>
 
   <p class='ptc'>
-    Even when data is present, accuracy is not guaranteed. ClinicalTrials.gov applies automated and manual checks for completeness and consistency, but submitted data is not independently verified. Errors and outliers (e.g., extremely high enrollment numbers) can occur.
+    Missing data may also result from unknown factors. Users should clearly define how missing and “N/A” values are handled in analyses—for example, whether to exclude or impute missing data (e.g., a single-arm study cannot be randomized).
   </p>
 
   <p class='ptc'>
-    ⚠️ Researchers should examine data distributions, handle missing values transparently, and run consistency checks before analysis. For fewer missing fields, consider limiting analyses to studies registered after September 2007 (when FDAAA requirements began).
+    To reduce missing data, users might restrict analyses to studies registered after FDAAA (September 2007) or with primary completion dates after December 2007. Annotating elements by FDAAA requirement status may also be helpful.
   </p>
 
-  <div class="info-box">
-    <h2>Use of appropriate statistical inference</h2>
+  <p class='ptc'>
+    Even complete data elements should be interpreted cautiously. Results on ClinicalTrials.gov may lack the rigorous peer-review of published studies. As <a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article">Zarin et al.</a> explain, NLM applies automated and manual quality checks but cannot always verify accuracy against independent sources. Posting does not guarantee full compliance with ClinicalTrials.gov or legal requirements.<sup><a target='_blank' href="http://www.nejm.org/doi/full/10.1056/NEJMsa1012065#t=article">[1]</a></sup>
+  </p>
 
-    <p class='ptc'>If the AACT results data are to be used to support a meta-analysis or systematic review of the safety or efficacy of a particular intervention, then standard methods of meta-analysis or systematic review (e.g., the <a target='_blank' href="http://annals.org/article.aspx?articleid=744664" onClick="ga('send','event','external link','guide page: PRISMA')">PRISMA statement</a> should be used to appropriately account for study-to-study variability and other sources of uncertainty or bias. We recommend that authors consider the following points when deciding whether to report p-values, confidence intervals, or other probability-based inference when performing aggregate analysis of the ClinicalTrials.gov database:  </p>
+  <p class='ptc'>
+    In our analysis, extreme values (e.g., anticipated enrollment of millions) were found. Users should review data distributions, apply appropriate methods, and perform consistency checks (e.g., matching the number of arms described to the study design) before analysis.
+  </p>
+
+  <h2>Use of appropriate statistical inference</h2>
+  <div class="info-box">
+    <p class='ptc'>
+      When using AACT results for meta-analyses or systematic reviews on intervention safety or efficacy, apply standard methods such as the <a target='_blank' href="http://annals.org/article.aspx?articleid=744664" onClick="ga('send','event','external link','guide page: PRISMA')">PRISMA statement</a> to properly account for variability and potential biases between studies. Authors should consider the following points before reporting p-values, confidence intervals, or other statistical inferences in aggregate analyses of ClinicalTrials.gov data:
+    </p>
   </div>
 
   <h2>Is the data-generating mechanism random?</h2>
   <p class='ptc'>
-    Methods of statistical inference such as p-values and 95% confidence intervals are most appropriate when used to quantify the uncertainty of estimates or comparisons due to a random process that generates the data. Examples of such processes include selection of a random sample of subjects from a broader population, randomly assigning a treatment to a cohort of subjects, or a coin toss about which we aim to predict future results.
+    Statistical inference methods like p-values and 95% confidence intervals are appropriate when data arise from a random process, such as randomly selecting subjects or assigning treatments, where uncertainty about the population exists.
   </p>
 
   <p class='ptc'>
-    In the following examples, we recommend against reporting p-values and 95% confidence intervals because the data-generating mechanism is not random.
+    We recommend against using p-values and confidence intervals when the data-generating mechanism is not random, as in the examples below:
   </p>
 
-  <ul class='regularDisplay'>
-    <li>
-      <b>Example 1:</b> Descriptive analysis of studies registered in the ClinicalTrials.gov database. In this case, the “sample” equals the “population” (i.e., the group about which we are making conclusions) and there is no role for statistical inference because there is no sample-vs-population uncertainty to be quantified.
-    </li>
-    <li>
-      <b>Example 2:</b> Descriptive analysis of the “clinical trials enterprise” as characterized by the studies registered in ClinicalTrials.gov. Despite mandates for study registration (Table 1), it may be that some studies that are required to be registered are not. In this case, the sample (studies registered in ClinicalTrials.gov) may not equal the population (clinical trials enterprise). However, it is likely that those studies not registered are not excluded at random, and therefore neither p-values nor confidence intervals are helpful to support extrapolation from the sample to the population. To support such extrapolation, we recommend careful consideration of the studies that are highly likely to be registered (see section above on Population), and to limit inference to this population so that sample-vs-population uncertainty is minimal.
-    </li>
-  </ul>
+  <p class='ptc'>
+    <b>Example 1:</b> Descriptive analysis of studies registered in ClinicalTrials.gov. Here, the “sample” is the entire “population” of registered studies, so there is no uncertainty to quantify, making statistical inference unnecessary.
+  </p>
+
+  <p class='ptc'>
+    <b>Example 2:</b> Descriptive analysis of the broader clinical trials enterprise based on registered studies. Some required studies may be unregistered, and this missingness is likely non-random. Thus, p-values and confidence intervals are not useful for extrapolating from registered studies to the entire clinical trials population. Instead, limit inference to studies highly likely to be registered (see section on Population) to minimize sample-to-population uncertainty.
+  </p>
 
   <h2>How can I objectively identify important differences?</h2>
+  <div class="info-box"> 
+    <p class='ptc'>
+      In practice, p-values and confidence intervals are often used even without a random data generating process to highlight differences that stand out from “noise” (e.g., p-value &lt; .001). Although this use lacks strong statistical grounding, many audiences (like peer reviewers) expect p-values as objective criteria for detecting notable signals. While we don’t recommend relying on p-values for this purpose, we encourage analysts to define clear, objective criteria for evaluating signals in the data. Examples include:
+    </p>
 
-  <p class='ptc'>In practice, p-values and confidence intervals are often employed even when there is no random data generating process to highlight differences that are larger than “noise” (e.g., authors may want to highlight differences with a p-value < .001).  While this practice may not have a strong foundation in statistical philosophy, we acknowledge that many audiences (e.g., journal peer reviewers) may demand p-values because they appear to provide objective criteria for identifying larger-than-expected signals in the data.  While we don’t encourage reporting of p-values for this purpose, we do encourage analysts to specify objective criteria for evaluating signals in the data.  Examples are provided:</p>
+    <p class='ptc'>a) Specify comparisons or quantities of interest before examining the data.</p>
 
-  <p class='ptc'>a) Prior to examining the data, specify comparisons of major interest, or quantities to be estimated. </p>
+    <p class='ptc'>b) Define the size of differences that are practically meaningful (e.g., a 25% difference in funding source between two pediatric <i>Conditions</i>, or a difference of 100 participants in enrollment).</p>
 
-  <p class='ptc'>b) Determine the magnitude of differences that would have practical significance.  (e.g., a 25% difference in source of funding between studies of 2 pediatric <i>Conditions</i>, or a difference in enrollment of 100 participants).  </p>
+    <p class='ptc'>c) Choose formulas to quantify differences or summarize variability, considering observed differences, data variability, and sample size. Examples include:</p>
 
-  <p class='ptc'>c) Determine appropriate formulas for quantifying differences between groups or summarizing population variability.  This quantification could take into account of the observed difference, variability in the data, and the number of observations.  Examples are provided:</p>
+    <ul class='regularDisplay'>
+      <li>Reporting median and 5th to 95th percentiles for continuous variables like enrollment.</li>
+      <li>Calculating t-statistics or chi-squared statistics (without p-values) to rank group differences, with a pre-set threshold (e.g., absolute value of 3) to flag notable differences.</li>
+    </ul>
+  </div>
 
-  <ul class='regularDisplay'>
-    <li>When summarizing a continuous characteristic such as enrollment, the analyst might choose to report the median and 5th to 95th percentiles.</li>
-    <li>To quantify signal to noise, the analyst could calculate a t-statistic or a chi-squared statistic (without the p-value) and rank differences between 2 groups based on these values.  The analyst might pre-specify a threshold (e.g., absolute value of 3) to flag notable differences.</li>
-  </ul>
 
   <h2>Specific tips for working with the AACT database</h2>
-
   <ul class='regularDisplay'>
     <li>Users are encouraged to use the <a href='/schema' target="_blank" onClick="ga('send','event','download','guide page: download schema')">Schema Diagram</a> to determine relationships between different AACT tables. These relationships determine how tables may be linked using tools such as SAS, R & SQL.</li>
     <li>The <i>nct_id</i> uniquely identifies each study; it serves as the primary key in the <i>Studies</i> table. Each record in the <i>Studies</i> table has a unique <i>nct_id</i> value. <i>nct_id</i> also appears in every table related to <i>Studies</i> so that every record in every table can link back to the study to which it refers.</li>
     <li>Every table other than <i>Studies</i> has a primary key named <i>id</i>, which provides an integer that uniquely identifies each row in that table. (The <i>Studies</i> table uses <i>nct_id</i> instead of <i>id</i> as the unique identifier for each row.)</li>
-    <li>To link table information to the study to which it refers, you simply match on <i>nct_id</i>. For example, every record in the <i><i>Conditions</i></i> table with an NCT_ID of ‘NCT0000001’ refers to the study with the NCT_ID: ‘NCT0000001’ (saved in <i>Studies.nct_id</i>). The <i>Conditions</i> table may contain multiple records with an NCT_ID of ‘NCT0000001’ which means this study was defined in ClinicalTrials.gov as being associated with the <i>Conditions</i> listed in <i>Conditions</i> with that NCT_ID.</li>
-    <li>Information in several tables are also related to information in other tables. In this case, the table that belongs to another table will include a foreign key that identifies the record to which it belongs. Foreign keys are always named according to a simple rule: the singular name of the related table followed by: ‘_id’.  For example, <i>Facility_Contacts</i> includes a data element: <i>facility_id</i> which is the foreign key to <i>Facilities.id</i></li>
-    <li>Each record’s foreign_key (ie. <i>facility_id</i>) contains the value of the unique identifier (id) of the record in the other table to which it belongs. For example, a facility may have multiple contacts. To find the contacts for a particular facility, look for the records in <i>Facility_Contacts</i> where the value in <i>facility_id</i> is same as the value in id for that facility in <i>Facilities</i>. In short, tables are related to each other with this pattern: <i>child.&lt;parent_name&gt;_id = parent.id</i> </li>
+    <li>To link table information to the study to which it refers, you simply match on <i>nct_id</i>. For example, every record in the <i>Conditions</i> table with an NCT_ID of ‘NCT0000001’ refers to the study with the NCT_ID: ‘NCT0000001’ (saved in <i>Studies.nct_id</i>). The <i>Conditions</i> table may contain multiple records with an NCT_ID of ‘NCT0000001’ which means this study was defined in ClinicalTrials.gov as being associated with the <i>Conditions</i> listed in <i>Conditions</i> with that NCT_ID.</li>
+    <li>Information in several tables are also related to information in other tables. In this case, the table that belongs to another table will include a foreign key that identifies the record to which it belongs. Foreign keys are always named according to a simple rule: the singular name of the related table followed by: ‘_id’. For example, <i>Facility_Contacts</i> includes a data element: <i>facility_id</i> which is the foreign key to <i>Facilities.id</i>.</li>
+    <li>Each record’s foreign_key (ie. <i>facility_id</i>) contains the value of the unique identifier (id) of the record in the other table to which it belongs. For example, a facility may have multiple contacts. To find the contacts for a particular facility, look for the records in <i>Facility_Contacts</i> where the value in <i>facility_id</i> is same as the value in id for that facility in <i>Facilities</i>. In short, tables are related to each other with this pattern: <i>child.&lt;parent_name&gt;_id = parent.id</i>.</li>
     <li>Note that the ID assigned to a particular record (e.g., to a record in the <i>Facilities</i> table) is merely the method used to identify unique records in the database table, and to facilitate linking of records between database tables. The ID does not identify unique facilities in the real world. For example, if studies A and B are both enrolling patients at Duke University Medical Center, there will be one instance of Duke University Medical Center for each study, and these records will have different ID values, even though they may be the same physical research site.</li>
   </ul>
 
   <p class='ptc'><%= render partial: 'schema_info' %></p>
-
 
   <h2>References</h2>
 


### PR DESCRIPTION
Edited from subheading "What is AACT ?" to "How does content in AACT compare to what is in ClinicalTrials.gov?"